### PR TITLE
Handle get-export-status responses

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -64,7 +64,11 @@ export function generateServerlessRouter(fhirConfig: FhirConfig, supportedGeneri
 
     // Export
     if (fhirConfig.profile.bulkDataAccess) {
-        const exportRoute = new ExportRoute(serverUrl, fhirConfig.profile.bulkDataAccess);
+        const exportRoute = new ExportRoute(
+            serverUrl,
+            fhirConfig.profile.bulkDataAccess,
+            fhirConfig.auth.authorization,
+        );
         app.use('/', exportRoute.router);
     }
 

--- a/src/router/handlers/exportHandler.ts
+++ b/src/router/handlers/exportHandler.ts
@@ -16,11 +16,11 @@ export default class ExportHandler {
         return this.bulkDataAccess.initiateExport(initiateExportRequest);
     }
 
-    async getExportJobStatus(jobId: string): Promise<GetExportStatusResponse> {
-        return this.bulkDataAccess.getExportStatus(jobId);
+    async getExportJobStatus(jobId: string, requesterUserId: string): Promise<GetExportStatusResponse> {
+        return this.bulkDataAccess.getExportStatus(jobId, requesterUserId);
     }
 
-    async cancelExport(jobId: string): Promise<void> {
-        await this.bulkDataAccess.cancelExport(jobId);
+    async cancelExport(jobId: string, requesterUserId: string): Promise<void> {
+        await this.bulkDataAccess.cancelExport(jobId, requesterUserId);
     }
 }

--- a/src/router/routes/errorHandling.ts
+++ b/src/router/routes/errorHandling.ts
@@ -1,7 +1,11 @@
 import express from 'express';
 import createError from 'http-errors';
-import { InvalidResourceError, ResourceNotFoundError, ResourceVersionNotFoundError } from 'fhir-works-on-aws-interface';
-import { TooManyConcurrentExportRequestsError } from 'fhir-works-on-aws-interface/lib/errors/TooManyConcurrentExportRequestsError';
+import {
+    InvalidResourceError,
+    ResourceNotFoundError,
+    ResourceVersionNotFoundError,
+    TooManyConcurrentExportRequestsError,
+} from 'fhir-works-on-aws-interface';
 import OperationsGenerator from '../operationsGenerator';
 
 export const applicationErrorMapper = (

--- a/src/router/routes/errorHandling.ts
+++ b/src/router/routes/errorHandling.ts
@@ -2,7 +2,6 @@ import express from 'express';
 import createError from 'http-errors';
 import { InvalidResourceError, ResourceNotFoundError, ResourceVersionNotFoundError } from 'fhir-works-on-aws-interface';
 import { TooManyConcurrentExportRequestsError } from 'fhir-works-on-aws-interface/lib/errors/TooManyConcurrentExportRequestsError';
-import { UnauthorizedAccessError } from 'fhir-works-on-aws-interface/lib/errors/UnauthorizedAccessError';
 import OperationsGenerator from '../operationsGenerator';
 
 export const applicationErrorMapper = (
@@ -26,10 +25,6 @@ export const applicationErrorMapper = (
     }
     if (err instanceof TooManyConcurrentExportRequestsError) {
         next(new createError.TooManyRequests('There is currently too many requests. Please try again later'));
-        return;
-    }
-    if (err instanceof UnauthorizedAccessError) {
-        next(new createError.Forbidden('Forbidden'));
         return;
     }
     next(err);

--- a/src/router/routes/errorHandling.ts
+++ b/src/router/routes/errorHandling.ts
@@ -2,6 +2,7 @@ import express from 'express';
 import createError from 'http-errors';
 import { InvalidResourceError, ResourceNotFoundError, ResourceVersionNotFoundError } from 'fhir-works-on-aws-interface';
 import { TooManyConcurrentExportRequestsError } from 'fhir-works-on-aws-interface/lib/errors/TooManyConcurrentExportRequestsError';
+import { UnauthorizedAccessError } from 'fhir-works-on-aws-interface/lib/errors/UnauthorizedAccessError';
 import OperationsGenerator from '../operationsGenerator';
 
 export const applicationErrorMapper = (
@@ -25,6 +26,10 @@ export const applicationErrorMapper = (
     }
     if (err instanceof TooManyConcurrentExportRequestsError) {
         next(new createError.TooManyRequests('There is currently too many requests. Please try again later'));
+        return;
+    }
+    if (err instanceof UnauthorizedAccessError) {
+        next(new createError.Forbidden('Forbidden'));
         return;
     }
     next(err);

--- a/src/router/routes/exportRoute.ts
+++ b/src/router/routes/exportRoute.ts
@@ -5,7 +5,7 @@
 
 /* eslint-disable no-underscore-dangle */
 import express, { Router } from 'express';
-import { BulkDataAccess, ExportType, InitiateExportRequest } from 'fhir-works-on-aws-interface';
+import { Authorization, BulkDataAccess, ExportType, InitiateExportRequest } from 'fhir-works-on-aws-interface';
 import createHttpError from 'http-errors';
 import RouteHelper from './routeHelper';
 import ExportHandler from '../handlers/exportHandler';
@@ -18,10 +18,10 @@ export default class ExportRoute {
 
     private serverUrl: string;
 
-    constructor(serverUrl: string, bulkDataAccess: BulkDataAccess) {
+    constructor(serverUrl: string, bulkDataAccess: BulkDataAccess, authService: Authorization) {
         this.router = express.Router();
         this.serverUrl = serverUrl;
-        this.exportHandler = new ExportHandler(bulkDataAccess);
+        this.exportHandler = new ExportHandler(bulkDataAccess, authService);
         this.init();
     }
 

--- a/src/router/routes/exportRoute.ts
+++ b/src/router/routes/exportRoute.ts
@@ -33,7 +33,7 @@ export default class ExportRoute {
         );
         const jobId = await this.exportHandler.initiateExport(initiateExportRequest);
 
-        const exportStatusUrl = `${this.serverUrl}/$export/${initiateExportRequest.requesterUserId}/${jobId}`;
+        const exportStatusUrl = `${this.serverUrl}/$export/${jobId}`;
         res.header('Content-Location', exportStatusUrl)
             .status(202)
             .send();
@@ -59,10 +59,11 @@ export default class ExportRoute {
 
         // Export Job Status
         this.router.get(
-            '/\\$export/:requesterUserId/:jobId',
+            '/\\$export/:jobId',
             RouteHelper.wrapAsync(async (req: express.Request, res: express.Response) => {
+                const { requesterUserId } = res.locals;
                 const { jobId } = req.params;
-                const response = await this.exportHandler.getExportJobStatus(jobId);
+                const response = await this.exportHandler.getExportJobStatus(jobId, requesterUserId);
                 if (response.jobStatus === 'in-progress') {
                     res.status(202)
                         .header('x-progress', 'in-progress')
@@ -95,10 +96,11 @@ export default class ExportRoute {
 
         // Cancel export job
         this.router.delete(
-            '/\\$export/:requesterUserId/:jobId',
+            '/\\$export/:jobId',
             RouteHelper.wrapAsync(async (req: express.Request, res: express.Response) => {
                 const { jobId } = req.params;
-                await this.exportHandler.cancelExport(jobId);
+                const { requesterUserId } = res.locals;
+                await this.exportHandler.cancelExport(jobId, requesterUserId);
                 res.status(202).send();
             }),
         );

--- a/src/router/routes/exportRouteHelper.test.ts
+++ b/src/router/routes/exportRouteHelper.test.ts
@@ -1,5 +1,6 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { mockRequest, mockResponse } from 'mock-req-res';
+import crypto from 'crypto';
 import ExportRouteHelper from './exportRouteHelper';
 import { utcTimeRegExp } from '../../regExpressions';
 

--- a/src/router/routes/exportRouteHelper.test.ts
+++ b/src/router/routes/exportRouteHelper.test.ts
@@ -1,6 +1,5 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { mockRequest, mockResponse } from 'mock-req-res';
-import { ExportType } from 'fhir-works-on-aws-interface';
 import ExportRouteHelper from './exportRouteHelper';
 import { utcTimeRegExp } from '../../regExpressions';
 
@@ -18,6 +17,9 @@ describe('buildInitiateExportRequest', () => {
                 _since: '2020-09-01T00:00:00Z',
                 _type: 'Patient',
             },
+            headers: {
+                prefer: 'respond-async',
+            },
         });
 
         const actualInitiateExportRequest = ExportRouteHelper.buildInitiateExportRequest(req, mockedResponse, 'system');
@@ -26,7 +28,7 @@ describe('buildInitiateExportRequest', () => {
             transactionTime: expect.stringMatching(utcTimeRegExp),
             exportType: 'system',
             outputFormat: 'ndjson',
-            since: '2020-09-01T00:00:00Z',
+            since: '2020-09-01T00:00:00.000Z',
             type: 'Patient',
         });
     });
@@ -35,7 +37,7 @@ describe('buildInitiateExportRequest', () => {
         const req = mockRequest({
             query: {
                 _outputFormat: 'ndjson',
-                _since: '2020-09-01T00:00:00Z',
+                _since: '2020-09-01T00:00:00.000Z',
                 _type: 'Patient',
             },
             params: {
@@ -49,7 +51,7 @@ describe('buildInitiateExportRequest', () => {
             transactionTime: expect.stringMatching(utcTimeRegExp),
             exportType: 'group',
             outputFormat: 'ndjson',
-            since: '2020-09-01T00:00:00Z',
+            since: '2020-09-01T00:00:00.000Z',
             type: 'Patient',
             groupId: '1',
         });
@@ -107,14 +109,13 @@ describe('buildInitiateExportRequest', () => {
         } catch (e) {
             expect(e.name).toEqual('BadRequestError');
             expect(e.message).toEqual(
-                "Query '_since' should be in the FHIR Instant format: YYYY-MM-DDThh:mm:ssZ. Exp. 2020-09-01T00:00:00Z",
+                "Query '_since' should be in the FHIR Instant format: YYYY-MM-DDThh:mm:ss.sss+zz:zz (e.g. 2015-02-07T13:28:17.239+02:00 or 2017-01-01T00:00:00Z)",
             );
         }
     });
 });
 
 describe('getExportUrl', () => {
-    // TODO: Add tests for subset of params
     describe('All params', () => {
         const baseUrl = 'http://API_URL.com';
         const outputFormat = 'ndjson';
@@ -138,6 +139,49 @@ describe('getExportUrl', () => {
             const result = ExportRouteHelper.getExportUrl(baseUrl, 'group', queryParams, groupId);
             expect(result).toEqual(
                 'http://api_url.com/Group/12/$export?_outputFormat=ndjson&_since=2020-09-02T00%3A00%3A00-05%3A00&_type=Patient',
+            );
+        });
+    });
+    describe('Subset params: only type', () => {
+        const baseUrl = 'http://API_URL.com';
+        const type = 'Patient';
+        const queryParams = { type };
+        const groupId = '12';
+        test('System', () => {
+            const result = ExportRouteHelper.getExportUrl(baseUrl, 'system', queryParams, groupId);
+            expect(result).toEqual('http://api_url.com/$export?_type=Patient');
+        });
+        test('Patient', () => {
+            const result = ExportRouteHelper.getExportUrl(baseUrl, 'patient', queryParams, groupId);
+            expect(result).toEqual('http://api_url.com/Patient/$export?_type=Patient');
+        });
+        test('Group', () => {
+            const result = ExportRouteHelper.getExportUrl(baseUrl, 'group', queryParams, groupId);
+            expect(result).toEqual('http://api_url.com/Group/12/$export?_type=Patient');
+        });
+    });
+    describe('Subset params: only outputFormat and since', () => {
+        const baseUrl = 'http://API_URL.com';
+        const outputFormat = 'ndjson';
+        const since = '2020-09-02T00:00:00-05:00';
+        const queryParams = { outputFormat, since };
+        const groupId = '12';
+        test('System', () => {
+            const result = ExportRouteHelper.getExportUrl(baseUrl, 'system', queryParams, groupId);
+            expect(result).toEqual(
+                'http://api_url.com/$export?_outputFormat=ndjson&_since=2020-09-02T00%3A00%3A00-05%3A00',
+            );
+        });
+        test('Patient', () => {
+            const result = ExportRouteHelper.getExportUrl(baseUrl, 'patient', queryParams, groupId);
+            expect(result).toEqual(
+                'http://api_url.com/Patient/$export?_outputFormat=ndjson&_since=2020-09-02T00%3A00%3A00-05%3A00',
+            );
+        });
+        test('Group', () => {
+            const result = ExportRouteHelper.getExportUrl(baseUrl, 'group', queryParams, groupId);
+            expect(result).toEqual(
+                'http://api_url.com/Group/12/$export?_outputFormat=ndjson&_since=2020-09-02T00%3A00%3A00-05%3A00',
             );
         });
     });

--- a/src/router/routes/exportRouteHelper.test.ts
+++ b/src/router/routes/exportRouteHelper.test.ts
@@ -1,5 +1,6 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { mockRequest, mockResponse } from 'mock-req-res';
+import { ExportType } from 'fhir-works-on-aws-interface';
 import ExportRouteHelper from './exportRouteHelper';
 import { utcTimeRegExp } from '../../regExpressions';
 
@@ -109,5 +110,35 @@ describe('buildInitiateExportRequest', () => {
                 "Query '_since' should be in the FHIR Instant format: YYYY-MM-DDThh:mm:ssZ. Exp. 2020-09-01T00:00:00Z",
             );
         }
+    });
+});
+
+describe('getExportUrl', () => {
+    // TODO: Add tests for subset of params
+    describe('All params', () => {
+        const baseUrl = 'http://API_URL.com';
+        const outputFormat = 'ndjson';
+        const since = '2020-09-02T00:00:00-05:00';
+        const type = 'Patient';
+        const queryParams = { outputFormat, since, type };
+        const groupId = '12';
+        test('System', () => {
+            const result = ExportRouteHelper.getExportUrl(baseUrl, 'system', queryParams, groupId);
+            expect(result).toEqual(
+                'http://api_url.com/$export?_outputFormat=ndjson&_since=2020-09-02T00%3A00%3A00-05%3A00&_type=Patient',
+            );
+        });
+        test('Patient', () => {
+            const result = ExportRouteHelper.getExportUrl(baseUrl, 'patient', queryParams, groupId);
+            expect(result).toEqual(
+                'http://api_url.com/Patient/$export?_outputFormat=ndjson&_since=2020-09-02T00%3A00%3A00-05%3A00&_type=Patient',
+            );
+        });
+        test('Group', () => {
+            const result = ExportRouteHelper.getExportUrl(baseUrl, 'group', queryParams, groupId);
+            expect(result).toEqual(
+                'http://api_url.com/Group/12/$export?_outputFormat=ndjson&_since=2020-09-02T00%3A00%3A00-05%3A00&_type=Patient',
+            );
+        });
     });
 });

--- a/src/router/routes/exportRouteHelper.test.ts
+++ b/src/router/routes/exportRouteHelper.test.ts
@@ -1,6 +1,5 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { mockRequest, mockResponse } from 'mock-req-res';
-import crypto from 'crypto';
 import ExportRouteHelper from './exportRouteHelper';
 import { utcTimeRegExp } from '../../regExpressions';
 

--- a/src/router/routes/exportRouteHelper.ts
+++ b/src/router/routes/exportRouteHelper.ts
@@ -10,7 +10,7 @@ export default class ExportRouteHelper {
         if (req.query._outputFormat && req.query._outputFormat !== 'ndjson') {
             throw new createHttpError.BadRequest('We only support exporting resources into ndjson formatted file');
         }
-        if (req.header('prefer') && req.header('prefer') !== 'respond-async') {
+        if (req.headers.prefer && req.headers.prefer !== 'respond-async') {
             throw new createHttpError.BadRequest('We only support asyncronous export job request');
         }
         if (

--- a/src/router/routes/exportRouteHelper.ts
+++ b/src/router/routes/exportRouteHelper.ts
@@ -10,6 +10,9 @@ export default class ExportRouteHelper {
         if (req.query._outputFormat && req.query._outputFormat !== 'ndjson') {
             throw new createHttpError.BadRequest('We only support exporting resources into ndjson formatted file');
         }
+        if (req.header('prefer') && req.header('prefer') !== 'respond-async') {
+            throw new createHttpError.BadRequest('We only support asyncronous export job request');
+        }
         if (
             (req.query._since && !isString(req.query._since)) ||
             (req.query._since && isString(req.query._since) && !dateTimeWithTimeZoneRegExp.test(req.query._since))
@@ -33,5 +36,34 @@ export default class ExportRouteHelper {
             groupId: isString(req.params.id) ? req.params.id : undefined,
         };
         return initiateExportRequest;
+    }
+
+    static getExportUrl(
+        baseUrl: string,
+        exportType: ExportType,
+        queryParams: { outputFormat?: string; since?: string; type?: string },
+        groupId?: string,
+    ) {
+        const { outputFormat, since, type } = queryParams;
+        const url = new URL(baseUrl);
+        if (exportType === 'system') {
+            url.pathname = '/$export';
+        }
+        if (exportType === 'patient') {
+            url.pathname = '/Patient/$export';
+        }
+        if (exportType === 'group') {
+            url.pathname = `/Group/${groupId}/$export`;
+        }
+        if (outputFormat) {
+            url.searchParams.append('_outputFormat', outputFormat);
+        }
+        if (since) {
+            url.searchParams.append('_since', since);
+        }
+        if (type) {
+            url.searchParams.append('_type', type);
+        }
+        return url.toString();
     }
 }


### PR DESCRIPTION
Description of changes:
* Added code to handle the different responses for an export status request.

**Related PRs**
* https://github.com/awslabs/fhir-works-on-aws-interface/pull/14
* https://github.com/awslabs/fhir-works-on-aws-authz-rbac/pull/8

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.