### PR TITLE
feat: Pass down allowed resource types to search service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.1.0] - 2020-09-25
+- feat: Pass down allowed resource types to search service
+
 ## [1.0.0] - 2020-08-31
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "ajv": "^6.11.0",
     "errorhandler": "^1.5.1",
     "express": "^4.17.1",
-    "fhir-works-on-aws-interface": "^1.0.0",
+    "fhir-works-on-aws-interface": "^2.0.0",
     "flat": "^5.0.0",
     "http-errors": "^1.8.0",
     "lodash": "^4.17.15",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fhir-works-on-aws-routing",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "FHIR Works on AWS routing implementation",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
@@ -28,10 +28,10 @@
     "prepublish": "tsc"
   },
   "dependencies": {
-    "fhir-works-on-aws-interface": "^1.0.0",
     "ajv": "^6.11.0",
     "errorhandler": "^1.5.1",
     "express": "^4.17.1",
+    "fhir-works-on-aws-interface": "^1.0.0",
     "flat": "^5.0.0",
     "http-errors": "^1.8.0",
     "lodash": "^4.17.15",

--- a/src/app.ts
+++ b/src/app.ts
@@ -42,15 +42,11 @@ export function generateServerlessRouter(fhirConfig: FhirConfig, supportedGeneri
         try {
             const requestInformation = getRequestInformation(req.method, req.path);
             const accessToken: string = cleanAuthHeader(req.headers.authorization);
-            const isAllowed: boolean = fhirConfig.auth.authorization.isAuthorized({
+            const isAllowed: boolean = await fhirConfig.auth.authorization.isAuthorized({
                 ...requestInformation,
                 accessToken,
             });
             if (isAllowed) {
-                res.locals.allowedResourceTypes = fhirConfig.auth.authorization.getAllowedResourceTypesForOperation({
-                    operation: requestInformation.operation,
-                    accessToken,
-                });
                 next();
             } else {
                 res.status(403).json({ message: 'Forbidden' });
@@ -77,7 +73,11 @@ export function generateServerlessRouter(fhirConfig: FhirConfig, supportedGeneri
                     serverUrl,
                 );
 
-                const route: GenericResourceRoute = new GenericResourceRoute(operations, resourceHandler);
+                const route: GenericResourceRoute = new GenericResourceRoute(
+                    operations,
+                    resourceHandler,
+                    fhirConfig.auth.authorization,
+                );
                 app.use(`/${resourceEntry[0]}`, route.router);
             }
         });
@@ -97,7 +97,11 @@ export function generateServerlessRouter(fhirConfig: FhirConfig, supportedGeneri
             serverUrl,
         );
 
-        const genericRoute: GenericResourceRoute = new GenericResourceRoute(genericOperations, genericResourceHandler);
+        const genericRoute: GenericResourceRoute = new GenericResourceRoute(
+            genericOperations,
+            genericResourceHandler,
+            fhirConfig.auth.authorization,
+        );
 
         // Set up Resource for each generic resource
         genericFhirResources.forEach(async (resourceType: string) => {

--- a/src/app.ts
+++ b/src/app.ts
@@ -47,6 +47,10 @@ export function generateServerlessRouter(fhirConfig: FhirConfig, supportedGeneri
                 accessToken,
             });
             if (isAllowed) {
+                res.locals.allowedResourceTypes = fhirConfig.auth.authorization.getAllowedResourceTypesForOperation({
+                    operation: requestInformation.operation,
+                    accessToken,
+                });
                 next();
             } else {
                 res.status(403).json({ message: 'Forbidden' });

--- a/src/router/handlers/CrudHandlerInterface.ts
+++ b/src/router/handlers/CrudHandlerInterface.ts
@@ -10,7 +10,7 @@ export default interface CrudHandlerInterface {
     read(resourceType: string, id: string): any;
     vRead(resourceType: string, id: string, vid: string): any;
     delete(resourceType: string, id: string): any;
-    typeSearch(resourceType: string, searchParams: any): any;
+    typeSearch(resourceType: string, searchParams: any, allowedResourceTypes: string[]): any;
     typeHistory(resourceType: string, searchParams: any): any;
     instanceHistory(resourceType: string, id: string, searchParams: any): any;
 }

--- a/src/router/handlers/resourceHandler.test.ts
+++ b/src/router/handlers/resourceHandler.test.ts
@@ -365,9 +365,20 @@ describe('Testing search', () => {
         });
 
         // OPERATE
-        const searchResponse: any = await resourceHandler.typeSearch('Patient', { name: 'Henry' }, []);
+        const searchResponse: any = await resourceHandler.typeSearch('Patient', { name: 'Henry' }, [
+            'Patient',
+            'Practitioner',
+        ]);
 
         // CHECK
+        expect(ElasticSearchService.typeSearch).toHaveBeenCalledWith({
+            allowedResourceTypes: ['Patient', 'Practitioner'],
+            baseUrl: 'https://API_URL.com',
+            queryParams: {
+                name: 'Henry',
+            },
+            resourceType: 'Patient',
+        });
         expect(searchResponse.resourceType).toEqual('Bundle');
         expect(searchResponse.meta).toBeDefined();
         expect(searchResponse.type).toEqual('searchset');

--- a/src/router/handlers/resourceHandler.test.ts
+++ b/src/router/handlers/resourceHandler.test.ts
@@ -365,7 +365,7 @@ describe('Testing search', () => {
         });
 
         // OPERATE
-        const searchResponse: any = await resourceHandler.typeSearch('Patient', { name: 'Henry' });
+        const searchResponse: any = await resourceHandler.typeSearch('Patient', { name: 'Henry' }, []);
 
         // CHECK
         expect(searchResponse.resourceType).toEqual('Bundle');
@@ -401,7 +401,7 @@ describe('Testing search', () => {
         });
 
         // OPERATE
-        const searchResponse: any = await resourceHandler.typeSearch('Patient', { name: 'Henry' });
+        const searchResponse: any = await resourceHandler.typeSearch('Patient', { name: 'Henry' }, []);
 
         // CHECK
         expect(searchResponse.resourceType).toEqual('Bundle');
@@ -425,7 +425,7 @@ describe('Testing search', () => {
         ElasticSearchService.typeSearch = jest.fn().mockRejectedValue(new Error('Boom!!'));
         try {
             // OPERATE
-            await resourceHandler.typeSearch('Patient', { name: 'Henry' });
+            await resourceHandler.typeSearch('Patient', { name: 'Henry' }, []);
         } catch (e) {
             // CHECK
             expect(e).toEqual(new Error('Boom!!'));
@@ -453,11 +453,15 @@ describe('Testing search', () => {
             });
 
             // OPERATE
-            const searchResponse: any = await resourceHandler.typeSearch('Patient', {
-                name: 'Henry',
-                [SEARCH_PAGINATION_PARAMS.PAGES_OFFSET]: 0,
-                [SEARCH_PAGINATION_PARAMS.COUNT]: 1,
-            });
+            const searchResponse: any = await resourceHandler.typeSearch(
+                'Patient',
+                {
+                    name: 'Henry',
+                    [SEARCH_PAGINATION_PARAMS.PAGES_OFFSET]: 0,
+                    [SEARCH_PAGINATION_PARAMS.COUNT]: 1,
+                },
+                [],
+            );
 
             // CHECK
             expect(searchResponse.resourceType).toEqual('Bundle');
@@ -505,11 +509,15 @@ describe('Testing search', () => {
             });
 
             // OPERATE
-            const searchResponse: any = await resourceHandler.typeSearch('Patient', {
-                name: 'Henry',
-                [SEARCH_PAGINATION_PARAMS.PAGES_OFFSET]: 1,
-                [SEARCH_PAGINATION_PARAMS.COUNT]: 1,
-            });
+            const searchResponse: any = await resourceHandler.typeSearch(
+                'Patient',
+                {
+                    name: 'Henry',
+                    [SEARCH_PAGINATION_PARAMS.PAGES_OFFSET]: 1,
+                    [SEARCH_PAGINATION_PARAMS.COUNT]: 1,
+                },
+                [],
+            );
 
             // CHECK
             expect(searchResponse.resourceType).toEqual('Bundle');
@@ -557,11 +565,15 @@ describe('Testing search', () => {
                 },
             });
             // OPERATE
-            const searchResponse: any = await resourceHandler.typeSearch('Patient', {
-                name: 'Henry',
-                [SEARCH_PAGINATION_PARAMS.PAGES_OFFSET]: 1,
-                [SEARCH_PAGINATION_PARAMS.COUNT]: 1,
-            });
+            const searchResponse: any = await resourceHandler.typeSearch(
+                'Patient',
+                {
+                    name: 'Henry',
+                    [SEARCH_PAGINATION_PARAMS.PAGES_OFFSET]: 1,
+                    [SEARCH_PAGINATION_PARAMS.COUNT]: 1,
+                },
+                [],
+            );
 
             // CHECK
             expect(searchResponse.resourceType).toEqual('Bundle');

--- a/src/router/handlers/resourceHandler.ts
+++ b/src/router/handlers/resourceHandler.ts
@@ -55,11 +55,12 @@ export default class ResourceHandler implements CrudHandlerInterface {
         return patchResponse.resource;
     }
 
-    async typeSearch(resourceType: string, queryParams: any) {
+    async typeSearch(resourceType: string, queryParams: any, allowedResourceTypes: string[]) {
         const searchResponse = await this.searchService.typeSearch({
             resourceType,
             queryParams,
             baseUrl: this.serverUrl,
+            allowedResourceTypes,
         });
         return BundleGenerator.generateBundle(
             this.serverUrl,

--- a/src/router/routes/genericResourceRoute.ts
+++ b/src/router/routes/genericResourceRoute.ts
@@ -4,7 +4,7 @@
  */
 
 import express, { Router } from 'express';
-import { TypeOperation } from 'fhir-works-on-aws-interface';
+import { Authorization, cleanAuthHeader, TypeOperation } from 'fhir-works-on-aws-interface';
 import createError from 'http-errors';
 import CrudHandlerInterface from '../handlers/CrudHandlerInterface';
 import RouteHelper from './routeHelper';
@@ -16,10 +16,13 @@ export default class GenericResourceRoute {
 
     private handler: CrudHandlerInterface;
 
-    constructor(operations: TypeOperation[], handler: CrudHandlerInterface) {
+    private readonly authService: Authorization;
+
+    constructor(operations: TypeOperation[], handler: CrudHandlerInterface, authService: Authorization) {
         this.operations = operations;
         this.handler = handler;
         this.router = express.Router();
+        this.authService = authService;
         this.init();
     }
 
@@ -96,10 +99,16 @@ export default class GenericResourceRoute {
                     // Get the ResourceType looks like '/Patient'
                     const resourceType = req.baseUrl.substr(1);
                     const searchParamQuery = req.query;
+
+                    const allowedResourceTypes = await this.authService.getAllowedResourceTypesForOperation({
+                        operation: 'search-type',
+                        accessToken: cleanAuthHeader(req.headers.authorization),
+                    });
+
                     const response = await this.handler.typeSearch(
                         resourceType,
                         searchParamQuery,
-                        res.locals.allowedResourceTypes,
+                        allowedResourceTypes,
                     );
                     res.send(response);
                 }),

--- a/src/router/routes/genericResourceRoute.ts
+++ b/src/router/routes/genericResourceRoute.ts
@@ -96,7 +96,11 @@ export default class GenericResourceRoute {
                     // Get the ResourceType looks like '/Patient'
                     const resourceType = req.baseUrl.substr(1);
                     const searchParamQuery = req.query;
-                    const response = await this.handler.typeSearch(resourceType, searchParamQuery);
+                    const response = await this.handler.typeSearch(
+                        resourceType,
+                        searchParamQuery,
+                        res.locals.allowedResourceTypes,
+                    );
                     res.send(response);
                 }),
             );

--- a/yarn.lock
+++ b/yarn.lock
@@ -541,6 +541,15 @@
     "@types/qs" "*"
     "@types/range-parser" "*"
 
+"@types/express-serve-static-core@^4.17.2":
+  version "4.17.13"
+  resolved "https://registry.yarnpkg.com/@types/express-serve-static-core/-/express-serve-static-core-4.17.13.tgz#d9af025e925fc8b089be37423b8d1eac781be084"
+  integrity sha512-RgDi5a4nuzam073lRGKTUIaL3eF2+H7LJvJ8eUnCI0wA6SNjXc44DCmWNiTLs/AZ7QlsFWZiw/gTG3nSQGL0fA==
+  dependencies:
+    "@types/node" "*"
+    "@types/qs" "*"
+    "@types/range-parser" "*"
+
 "@types/express@*", "@types/express@^4.17.2":
   version "4.17.7"
   resolved "https://registry.yarnpkg.com/@types/express/-/express-4.17.7.tgz#42045be6475636d9801369cd4418ef65cdb0dd59"
@@ -1914,10 +1923,10 @@ fb-watchman@^2.0.0:
   dependencies:
     bser "2.1.1"
 
-fhir-works-on-aws-interface@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/fhir-works-on-aws-interface/-/fhir-works-on-aws-interface-1.0.0.tgz#7de73929ebab013745582518f7596607c85a4ad0"
-  integrity sha512-b+B7D4/Msfzku/efM7dhbqCANEjCEKqUm7YJwEsQVjfmNbyRHWNmk+Mer89POmPnbw0eqryjnvV7C698C/8+rQ==
+fhir-works-on-aws-interface@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/fhir-works-on-aws-interface/-/fhir-works-on-aws-interface-2.0.0.tgz#98c04208c32653f9d75743663c036f1d6eae6ffb"
+  integrity sha512-hdjZJaNEoSYXYVEDOtCQW/HxnQhnF2Nu02nzgeNEWdsZN8MiMakmLX/JxnPYmG13/L9J69CpeV1PmZCsT9HG3g==
 
 figures@^3.0.0:
   version "3.2.0"


### PR DESCRIPTION
Description of changes:

Call `auth.resourceTypesAllowedForOperation()` and pass down the results to search as described on https://github.com/awslabs/fhir-works-on-aws-interface/pull/16

Note: Need to publish the updated interface to npm first. Until then, checks are failing.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.