### PR TITLE
fix: metadata and well-known endpoint should not have any auth

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -51,6 +51,17 @@ export function generateServerlessRouter(
         hasCORSEnabled = true;
     }
 
+    // Metadata
+    const metadataRoute: MetadataRoute = new MetadataRoute(fhirVersion, configHandler, hasCORSEnabled);
+    app.use('/metadata', metadataRoute.router);
+
+    // well-known URI http://www.hl7.org/fhir/smart-app-launch/conformance/index.html#using-well-known
+    const smartStrat: SmartStrategy = fhirConfig.auth.strategy.oauthPolicy as SmartStrategy;
+    if (smartStrat.capabilities) {
+        const wellKnownUriRoute = new WellKnownUriRouteRoute(smartStrat);
+        app.use('/.well-known/smart-configuration', wellKnownUriRoute.router);
+    }
+
     // AuthZ
     app.use(async (req: express.Request, res: express.Response, next: express.NextFunction) => {
         try {
@@ -66,17 +77,6 @@ export function generateServerlessRouter(
             next(e);
         }
     });
-
-    // Metadata
-    const metadataRoute: MetadataRoute = new MetadataRoute(fhirVersion, configHandler, hasCORSEnabled);
-    app.use('/metadata', metadataRoute.router);
-
-    // well-known URI http://www.hl7.org/fhir/smart-app-launch/conformance/index.html#using-well-known
-    const smartStrat: SmartStrategy = fhirConfig.auth.strategy.oauthPolicy as SmartStrategy;
-    if (smartStrat.capabilities) {
-        const wellKnownUriRoute = new WellKnownUriRouteRoute(smartStrat);
-        app.use('/.well-known/smart-configuration', wellKnownUriRoute.router);
-    }
 
     // Export
     if (fhirConfig.profile.bulkDataAccess) {


### PR DESCRIPTION
Description of changes:

FHIR and SMART-on-FHIR require that the /metadata and /.well-known/smart-configuration endpoint NOT be behind auth. 

This change shifts the registration of these routes in the express router above the authentication middleware hook, so they are evaluated before auth kicks in. I think it makes more sense to make this change here than add conditional logic in the concrete implementations of `Authorization.verifyAccessToken()` to skip access token verification. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.