### PR TITLE
chore: Explicity check if Auth strategy is SMART-on-FHIR before adding well-known route

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "lint-fix": "eslint --fix . --ext .ts,.tsx",
     "build": "tsc",
     "watch": "tsc -w",
-    "test": "jest --silent --passWithNoTests",
+    "test": "jest --silent",
     "test-coverage": "jest --coverage",
     "release": "yarn run build && yarn run lint && yarn run test",
     "clean": "rm -rf build/* node_modules/* dist/* .serverless/* .nyc_output/* lib/*",

--- a/src/app.ts
+++ b/src/app.ts
@@ -55,11 +55,13 @@ export function generateServerlessRouter(
     const metadataRoute: MetadataRoute = new MetadataRoute(fhirVersion, configHandler, hasCORSEnabled);
     app.use('/metadata', metadataRoute.router);
 
-    // well-known URI http://www.hl7.org/fhir/smart-app-launch/conformance/index.html#using-well-known
-    const smartStrat: SmartStrategy = fhirConfig.auth.strategy.oauthPolicy as SmartStrategy;
-    if (smartStrat.capabilities) {
-        const wellKnownUriRoute = new WellKnownUriRouteRoute(smartStrat);
-        app.use('/.well-known/smart-configuration', wellKnownUriRoute.router);
+    if (fhirConfig.auth.strategy.service === 'SMART-on-FHIR') {
+        // well-known URI http://www.hl7.org/fhir/smart-app-launch/conformance/index.html#using-well-known
+        const smartStrat: SmartStrategy = fhirConfig.auth.strategy.oauthPolicy as SmartStrategy;
+        if (smartStrat.capabilities) {
+            const wellKnownUriRoute = new WellKnownUriRouteRoute(smartStrat);
+            app.use('/.well-known/smart-configuration', wellKnownUriRoute.router);
+        }
     }
 
     // AuthZ


### PR DESCRIPTION
chore: Explicity check if Auth strategy is SMART-on-FHIR before adding well-known route

Issue #, if available:

Description of changes:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.