### PR TITLE
fix: When parsing Bundles for reference only fields explicitly named  'reference' should be considered a reference

### DIFF
--- a/src/router/bundle/bundleParser.ts
+++ b/src/router/bundle/bundleParser.ts
@@ -309,7 +309,7 @@ export default class BundleParser {
      */
     private static getReferences(entry: any): Reference[] {
         const flattenResource: any = flatten(get(entry, 'resource', {}));
-        const referencePaths: string[] = Object.keys(flattenResource).filter(key => key.includes('reference'));
+        const referencePaths: string[] = Object.keys(flattenResource).filter(key => key.endsWith('.reference'));
         if (referencePaths.length === 0) {
             return [];
         }


### PR DESCRIPTION
Issue #, if available:
FHIR-450

Description of changes:
fix: When parsing Bundles for reference only fields explicitly named  'reference' should be considered a reference

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.