### PR TITLE
Use get search filter based on identity

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "cors": "^2.8.5",
     "errorhandler": "^1.5.1",
     "express": "^4.17.1",
-    "fhir-works-on-aws-interface": "^6.0.0",
+    "fhir-works-on-aws-interface": "^6.0.1",
     "flat": "^5.0.0",
     "http-errors": "^1.8.0",
     "lodash": "^4.17.15",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "cors": "^2.8.5",
     "errorhandler": "^1.5.1",
     "express": "^4.17.1",
-    "fhir-works-on-aws-interface": "^5.0.0",
+    "fhir-works-on-aws-interface": "^6.0.0",
     "flat": "^5.0.0",
     "http-errors": "^1.8.0",
     "lodash": "^4.17.15",

--- a/src/app.ts
+++ b/src/app.ts
@@ -99,6 +99,7 @@ export function generateServerlessRouter(
                     persistence,
                     typeSearch,
                     typeHistory,
+                    fhirConfig.auth.authorization,
                     fhirVersion,
                     serverUrl,
                 );
@@ -123,6 +124,7 @@ export function generateServerlessRouter(
             genericResource.persistence,
             genericResource.typeSearch,
             genericResource.typeHistory,
+            fhirConfig.auth.authorization,
             fhirVersion,
             serverUrl,
         );

--- a/src/router/bundle/bundleHandler.test.ts
+++ b/src/router/bundle/bundleHandler.test.ts
@@ -643,6 +643,10 @@ describe('ERROR Cases: Bundle not authorized', () => {
             async getAllowedResourceTypesForOperation(request) {
                 return [];
             },
+            // eslint-disable-next-line @typescript-eslint/no-unused-vars
+            async getSearchFilterBasedOnIdentity(request) {
+                return [];
+            },
         };
         const bundleHandlerWithStubbedAuthZ = new BundleHandler(
             DynamoDbBundleService,
@@ -680,6 +684,10 @@ describe('ERROR Cases: Bundle not authorized', () => {
             async isAccessBulkDataJobAllowed(request: AccessBulkDataJobRequest) {},
             // eslint-disable-next-line @typescript-eslint/no-unused-vars
             async getAllowedResourceTypesForOperation(request) {
+                return [];
+            },
+            // eslint-disable-next-line @typescript-eslint/no-unused-vars
+            async getSearchFilterBasedOnIdentity(request) {
                 return [];
             },
         };

--- a/src/router/handlers/CrudHandlerInterface.ts
+++ b/src/router/handlers/CrudHandlerInterface.ts
@@ -14,5 +14,5 @@ export default interface CrudHandlerInterface {
     delete(resourceType: string, id: string): any;
     typeSearch(resourceType: string, searchParams: any, allowedResourceTypes: string[], userIdentity: KeyValueMap): any;
     typeHistory(resourceType: string, searchParams: any, userIdentity: KeyValueMap): any;
-    instanceHistory(resourceType: string, id: string, searchParams: any): any;
+    instanceHistory(resourceType: string, id: string, searchParams: any, userIdentity: KeyValueMap): any;
 }

--- a/src/router/handlers/CrudHandlerInterface.ts
+++ b/src/router/handlers/CrudHandlerInterface.ts
@@ -3,6 +3,8 @@
  *  SPDX-License-Identifier: Apache-2.0
  */
 
+import { KeyValueMap } from 'fhir-works-on-aws-interface';
+
 export default interface CrudHandlerInterface {
     create(resourceType: string, resource: any): any;
     update(resourceType: string, id: string, resource: any): any;
@@ -10,7 +12,7 @@ export default interface CrudHandlerInterface {
     read(resourceType: string, id: string): any;
     vRead(resourceType: string, id: string, vid: string): any;
     delete(resourceType: string, id: string): any;
-    typeSearch(resourceType: string, searchParams: any, allowedResourceTypes: string[]): any;
-    typeHistory(resourceType: string, searchParams: any): any;
+    typeSearch(resourceType: string, searchParams: any, allowedResourceTypes: string[], userIdentity: KeyValueMap): any;
+    typeHistory(resourceType: string, searchParams: any, userIdentity: KeyValueMap): any;
     instanceHistory(resourceType: string, id: string, searchParams: any): any;
 }

--- a/src/router/handlers/resourceHandler.test.ts
+++ b/src/router/handlers/resourceHandler.test.ts
@@ -43,6 +43,7 @@ describe('SUCCESS CASES: Testing create, read, update, delete of resources', () 
         DynamoDbDataService,
         ElasticSearchService,
         stubs.history,
+        stubs.passThroughAuthz,
         '4.0.1',
         'https://API_URL.com',
     );
@@ -226,6 +227,7 @@ describe('ERROR CASES: Testing create, read, update, delete of resources', () =>
         mockedDataService,
         ElasticSearchService,
         stubs.history,
+        stubs.passThroughAuthz,
         '4.0.1',
         'https://API_URL.com',
     );
@@ -348,6 +350,7 @@ describe('Testing search', () => {
             DynamoDbDataService,
             ElasticSearchService,
             stubs.history,
+            stubs.passThroughAuthz,
             '4.0.1',
             'https://API_URL.com',
         );
@@ -379,10 +382,12 @@ describe('Testing search', () => {
         });
 
         // OPERATE
-        const searchResponse: any = await resourceHandler.typeSearch('Patient', { name: 'Henry' }, [
+        const searchResponse: any = await resourceHandler.typeSearch(
             'Patient',
-            'Practitioner',
-        ]);
+            { name: 'Henry' },
+            ['Patient', 'Practitioner'],
+            {},
+        );
 
         // CHECK
         expect(ElasticSearchService.typeSearch).toHaveBeenCalledWith({
@@ -392,6 +397,7 @@ describe('Testing search', () => {
                 name: 'Henry',
             },
             resourceType: 'Patient',
+            searchFilters: [],
         });
         expect(searchResponse.resourceType).toEqual('Bundle');
         expect(searchResponse.meta).toBeDefined();
@@ -426,7 +432,7 @@ describe('Testing search', () => {
         });
 
         // OPERATE
-        const searchResponse: any = await resourceHandler.typeSearch('Patient', { name: 'Henry' }, []);
+        const searchResponse: any = await resourceHandler.typeSearch('Patient', { name: 'Henry' }, [], {});
 
         // CHECK
         expect(searchResponse.resourceType).toEqual('Bundle');
@@ -450,7 +456,7 @@ describe('Testing search', () => {
         ElasticSearchService.typeSearch = jest.fn().mockRejectedValue(new Error('Boom!!'));
         try {
             // OPERATE
-            await resourceHandler.typeSearch('Patient', { name: 'Henry' }, []);
+            await resourceHandler.typeSearch('Patient', { name: 'Henry' }, [], {});
         } catch (e) {
             // CHECK
             expect(e).toEqual(new Error('Boom!!'));
@@ -486,6 +492,7 @@ describe('Testing search', () => {
                     [SEARCH_PAGINATION_PARAMS.COUNT]: 1,
                 },
                 [],
+                {},
             );
 
             // CHECK
@@ -542,6 +549,7 @@ describe('Testing search', () => {
                     [SEARCH_PAGINATION_PARAMS.COUNT]: 1,
                 },
                 [],
+                {},
             );
 
             // CHECK
@@ -598,6 +606,7 @@ describe('Testing search', () => {
                     [SEARCH_PAGINATION_PARAMS.COUNT]: 1,
                 },
                 [],
+                {},
             );
 
             // CHECK
@@ -641,6 +650,7 @@ describe('Testing history', () => {
             DynamoDbDataService,
             ElasticSearchService,
             stubs.history,
+            stubs.passThroughAuthz,
             '4.0.1',
             'https://API_URL.com',
         );
@@ -672,7 +682,7 @@ describe('Testing history', () => {
         });
 
         // OPERATE
-        const searchResponse: any = await resourceHandler.typeHistory('Patient', { name: 'Henry' });
+        const searchResponse: any = await resourceHandler.typeHistory('Patient', { name: 'Henry' }, {});
 
         // CHECK
         expect(searchResponse.resourceType).toEqual('Bundle');
@@ -708,7 +718,7 @@ describe('Testing history', () => {
         });
 
         // OPERATE
-        const searchResponse: any = await resourceHandler.typeHistory('Patient', { name: 'Henry' });
+        const searchResponse: any = await resourceHandler.typeHistory('Patient', { name: 'Henry' }, {});
 
         // CHECK
         expect(searchResponse.resourceType).toEqual('Bundle');
@@ -732,7 +742,7 @@ describe('Testing history', () => {
         stubs.history.typeHistory = jest.fn().mockRejectedValue(new Error('Boom!!'));
         try {
             // OPERATE
-            await resourceHandler.typeHistory('Patient', { name: 'Henry' });
+            await resourceHandler.typeHistory('Patient', { name: 'Henry' }, {});
         } catch (e) {
             // CHECK
             expect(e).toEqual(new Error('Boom!!'));
@@ -817,11 +827,15 @@ describe('Testing history', () => {
             });
 
             // OPERATE
-            const searchResponse: any = await resourceHandler.typeHistory('Patient', {
-                name: 'Henry',
-                [SEARCH_PAGINATION_PARAMS.PAGES_OFFSET]: 0,
-                [SEARCH_PAGINATION_PARAMS.COUNT]: 1,
-            });
+            const searchResponse: any = await resourceHandler.typeHistory(
+                'Patient',
+                {
+                    name: 'Henry',
+                    [SEARCH_PAGINATION_PARAMS.PAGES_OFFSET]: 0,
+                    [SEARCH_PAGINATION_PARAMS.COUNT]: 1,
+                },
+                {},
+            );
 
             // CHECK
             expect(searchResponse.resourceType).toEqual('Bundle');
@@ -869,11 +883,15 @@ describe('Testing history', () => {
             });
 
             // OPERATE
-            const searchResponse: any = await resourceHandler.typeHistory('Patient', {
-                name: 'Henry',
-                [SEARCH_PAGINATION_PARAMS.PAGES_OFFSET]: 1,
-                [SEARCH_PAGINATION_PARAMS.COUNT]: 1,
-            });
+            const searchResponse: any = await resourceHandler.typeHistory(
+                'Patient',
+                {
+                    name: 'Henry',
+                    [SEARCH_PAGINATION_PARAMS.PAGES_OFFSET]: 1,
+                    [SEARCH_PAGINATION_PARAMS.COUNT]: 1,
+                },
+                {},
+            );
 
             // CHECK
             expect(searchResponse.resourceType).toEqual('Bundle');
@@ -922,11 +940,15 @@ describe('Testing history', () => {
             });
 
             // OPERATE
-            const searchResponse: any = await resourceHandler.typeHistory('Patient', {
-                name: 'Henry',
-                [SEARCH_PAGINATION_PARAMS.PAGES_OFFSET]: 1,
-                [SEARCH_PAGINATION_PARAMS.COUNT]: 1,
-            });
+            const searchResponse: any = await resourceHandler.typeHistory(
+                'Patient',
+                {
+                    name: 'Henry',
+                    [SEARCH_PAGINATION_PARAMS.PAGES_OFFSET]: 1,
+                    [SEARCH_PAGINATION_PARAMS.COUNT]: 1,
+                },
+                {},
+            );
 
             // CHECK
             expect(searchResponse.resourceType).toEqual('Bundle');

--- a/src/router/handlers/resourceHandler.test.ts
+++ b/src/router/handlers/resourceHandler.test.ts
@@ -768,7 +768,7 @@ describe('Testing history', () => {
         });
 
         // OPERATE
-        const searchResponse: any = await resourceHandler.instanceHistory('Patient', 'id123', { name: 'Henry' });
+        const searchResponse: any = await resourceHandler.instanceHistory('Patient', 'id123', { name: 'Henry' }, {});
 
         // CHECK
         expect(searchResponse.resourceType).toEqual('Bundle');
@@ -799,7 +799,7 @@ describe('Testing history', () => {
         stubs.history.instanceHistory = jest.fn().mockRejectedValue(new Error('Boom!!'));
         try {
             // OPERATE
-            await resourceHandler.instanceHistory('Patient', 'id123', { name: 'Henry' });
+            await resourceHandler.instanceHistory('Patient', 'id123', { name: 'Henry' }, {});
         } catch (e) {
             // CHECK
             expect(e).toEqual(new Error('Boom!!'));

--- a/src/router/handlers/resourceHandler.ts
+++ b/src/router/handlers/resourceHandler.ts
@@ -3,7 +3,7 @@
  *  SPDX-License-Identifier: Apache-2.0
  */
 
-import { Search, History, Persistence, FhirVersion } from 'fhir-works-on-aws-interface';
+import { Search, History, Persistence, FhirVersion, Authorization, KeyValueMap } from 'fhir-works-on-aws-interface';
 import BundleGenerator from '../bundle/bundleGenerator';
 import CrudHandlerInterface from './CrudHandlerInterface';
 import OperationsGenerator from '../operationsGenerator';
@@ -18,12 +18,15 @@ export default class ResourceHandler implements CrudHandlerInterface {
 
     private historyService: History;
 
+    private authService: Authorization;
+
     private serverUrl: string;
 
     constructor(
         dataService: Persistence,
         searchService: Search,
         historyService: History,
+        authService: Authorization,
         fhirVersion: FhirVersion,
         serverUrl: string,
     ) {
@@ -31,6 +34,7 @@ export default class ResourceHandler implements CrudHandlerInterface {
         this.dataService = dataService;
         this.searchService = searchService;
         this.historyService = historyService;
+        this.authService = authService;
         this.serverUrl = serverUrl;
     }
 
@@ -55,12 +59,23 @@ export default class ResourceHandler implements CrudHandlerInterface {
         return patchResponse.resource;
     }
 
-    async typeSearch(resourceType: string, queryParams: any, allowedResourceTypes: string[]) {
+    async typeSearch(
+        resourceType: string,
+        queryParams: any,
+        allowedResourceTypes: string[],
+        userIdentity: KeyValueMap,
+    ) {
+        const searchFilters = await this.authService.getSearchFilterBasedOnIdentity({
+            userIdentity,
+            operation: 'search-type',
+        });
+
         const searchResponse = await this.searchService.typeSearch({
             resourceType,
             queryParams,
             baseUrl: this.serverUrl,
             allowedResourceTypes,
+            searchFilters,
         });
         return BundleGenerator.generateBundle(
             this.serverUrl,
@@ -71,11 +86,17 @@ export default class ResourceHandler implements CrudHandlerInterface {
         );
     }
 
-    async typeHistory(resourceType: string, queryParams: any) {
+    async typeHistory(resourceType: string, queryParams: any, userIdentity: KeyValueMap) {
+        const searchFilters = await this.authService.getSearchFilterBasedOnIdentity({
+            userIdentity,
+            operation: 'history-type',
+        });
+
         const historyResponse = await this.historyService.typeHistory({
             resourceType,
             queryParams,
             baseUrl: this.serverUrl,
+            searchFilters,
         });
         return BundleGenerator.generateBundle(
             this.serverUrl,

--- a/src/router/handlers/resourceHandler.ts
+++ b/src/router/handlers/resourceHandler.ts
@@ -107,12 +107,18 @@ export default class ResourceHandler implements CrudHandlerInterface {
         );
     }
 
-    async instanceHistory(resourceType: string, id: string, queryParams: any) {
+    async instanceHistory(resourceType: string, id: string, queryParams: any, userIdentity: KeyValueMap) {
+        const searchFilters = await this.authService.getSearchFilterBasedOnIdentity({
+            userIdentity,
+            operation: 'history-instance',
+        });
+
         const historyResponse = await this.historyService.instanceHistory({
             id,
             resourceType,
             queryParams,
             baseUrl: this.serverUrl,
+            searchFilters,
         });
         return BundleGenerator.generateBundle(
             this.serverUrl,

--- a/src/router/handlers/rootHandler.ts
+++ b/src/router/handlers/rootHandler.ts
@@ -3,7 +3,7 @@
  *  SPDX-License-Identifier: Apache-2.0
  */
 
-import { Search, History } from 'fhir-works-on-aws-interface';
+import { Search, History, KeyValueMap, Authorization } from 'fhir-works-on-aws-interface';
 import BundleGenerator from '../bundle/bundleGenerator';
 
 export default class RootHandler {
@@ -11,26 +11,39 @@ export default class RootHandler {
 
     private historyService: History;
 
+    private authService: Authorization;
+
     private serverUrl: string;
 
-    constructor(searchService: Search, historyService: History, serverUrl: string) {
+    constructor(searchService: Search, historyService: History, authService: Authorization, serverUrl: string) {
         this.searchService = searchService;
         this.historyService = historyService;
+        this.authService = authService;
         this.serverUrl = serverUrl;
     }
 
-    async globalSearch(queryParams: any) {
+    async globalSearch(queryParams: any, userIdentity: KeyValueMap) {
+        const searchFilters = await this.authService.getSearchFilterBasedOnIdentity({
+            userIdentity,
+            operation: 'search-system',
+        });
         const searchResponse = await this.searchService.globalSearch({
             queryParams,
             baseUrl: this.serverUrl,
+            searchFilters,
         });
         return BundleGenerator.generateBundle(this.serverUrl, queryParams, searchResponse.result, 'searchset');
     }
 
-    async globalHistory(queryParams: any) {
+    async globalHistory(queryParams: any, userIdentity: KeyValueMap) {
+        const searchFilters = await this.authService.getSearchFilterBasedOnIdentity({
+            userIdentity,
+            operation: 'history-system',
+        });
         const historyResponse = await this.historyService.globalHistory({
             queryParams,
             baseUrl: this.serverUrl,
+            searchFilters,
         });
         return BundleGenerator.generateBundle(this.serverUrl, queryParams, historyResponse.result, 'history');
     }

--- a/src/router/metadata/metadataHandler.test.ts
+++ b/src/router/metadata/metadataHandler.test.ts
@@ -12,6 +12,7 @@ import stu3FhirConfigWithExclusions from '../../../sampleData/stu3FhirConfigWith
 import r4FhirConfigNoGeneric from '../../../sampleData/r4FhirConfigNoGeneric';
 import Validator from '../validation/validator';
 import ConfigHandler from '../../configHandler';
+import { utcTimeRegExp } from '../../regExpressions';
 
 const r4Validator = new Validator('4.0.1');
 const stu3Validator = new Validator('3.0.1');
@@ -628,7 +629,7 @@ test('R4: FHIR Config V4 with all productInfo params', async () => {
     const metadataHandler: MetadataHandler = new MetadataHandler(configHandler);
     const response = await metadataHandler.capabilities({ fhirVersion: '4.0.1', mode: 'full' });
 
-    expect(response.resource).toEqual({
+    const expectedResponse: any = {
         resourceType: 'CapabilityStatement',
         name: 'product.machine.name',
         title: 'Product Title Capability Statement',
@@ -636,7 +637,6 @@ test('R4: FHIR Config V4 with all productInfo params', async () => {
         purpose: 'Product Purpose',
         copyright: 'Copyright',
         status: 'active',
-        date: new Date().toISOString(),
         publisher: 'Organization Name',
         kind: 'instance',
         software: {
@@ -650,5 +650,9 @@ test('R4: FHIR Config V4 with all productInfo params', async () => {
         fhirVersion: '4.0.1',
         format: ['json'],
         rest: response.resource.rest,
-    });
+    };
+
+    expectedResponse.date = expect.stringMatching(utcTimeRegExp);
+
+    expect(response.resource).toEqual(expectedResponse);
 });

--- a/src/router/metadata/metadataHandler.test.ts
+++ b/src/router/metadata/metadataHandler.test.ts
@@ -637,6 +637,7 @@ test('R4: FHIR Config V4 with all productInfo params', async () => {
         purpose: 'Product Purpose',
         copyright: 'Copyright',
         status: 'active',
+        date: expect.stringMatching(utcTimeRegExp),
         publisher: 'Organization Name',
         kind: 'instance',
         software: {
@@ -652,7 +653,5 @@ test('R4: FHIR Config V4 with all productInfo params', async () => {
         rest: response.resource.rest,
     };
 
-    expectedResponse.date = expect.stringMatching(utcTimeRegExp);
-
-    expect(response.resource).toEqual(expectedResponse);
+    expect(response.resource).toMatchObject(expectedResponse);
 });

--- a/src/router/routes/genericResourceRoute.ts
+++ b/src/router/routes/genericResourceRoute.ts
@@ -110,7 +110,12 @@ export default class GenericResourceRoute {
                     const resourceType = req.baseUrl.substr(1);
                     const searchParamQuery = req.query;
                     const { id } = req.params;
-                    const response = await this.handler.instanceHistory(resourceType, id, searchParamQuery);
+                    const response = await this.handler.instanceHistory(
+                        resourceType,
+                        id,
+                        searchParamQuery,
+                        res.locals.userIdentity,
+                    );
                     const updatedReadResponse = await this.authService.authorizeAndFilterReadResponse({
                         operation: 'history-instance',
                         userIdentity: res.locals.userIdentity,

--- a/src/router/routes/genericResourceRoute.ts
+++ b/src/router/routes/genericResourceRoute.ts
@@ -86,7 +86,11 @@ export default class GenericResourceRoute {
                     // Get the ResourceType looks like '/Patient'
                     const resourceType = req.baseUrl.substr(1);
                     const searchParamQuery = req.query;
-                    const response = await this.handler.typeHistory(resourceType, searchParamQuery);
+                    const response = await this.handler.typeHistory(
+                        resourceType,
+                        searchParamQuery,
+                        res.locals.userIdentity,
+                    );
                     const updatedReadResponse = await this.authService.authorizeAndFilterReadResponse({
                         operation: 'history-type',
                         userIdentity: res.locals.userIdentity,
@@ -135,6 +139,7 @@ export default class GenericResourceRoute {
                         resourceType,
                         searchParamQuery,
                         allowedResourceTypes,
+                        res.locals.userIdentity,
                     );
                     const updatedReadResponse = await this.authService.authorizeAndFilterReadResponse({
                         operation: 'search-type',

--- a/src/router/routes/rootRoute.ts
+++ b/src/router/routes/rootRoute.ts
@@ -54,7 +54,7 @@ export default class RootRoute {
             resources,
         );
         this.authService = authService;
-        this.rootHandler = new RootHandler(search, history, serverUrl);
+        this.rootHandler = new RootHandler(search, history, authService, serverUrl);
         this.init();
     }
 
@@ -87,7 +87,7 @@ export default class RootRoute {
                 '/',
                 RouteHelper.wrapAsync(async (req: express.Request, res: express.Response) => {
                     const searchParamQuery = req.query;
-                    const response = await this.rootHandler.globalSearch(searchParamQuery);
+                    const response = await this.rootHandler.globalSearch(searchParamQuery, res.locals.userIdentity);
                     const updatedReadResponse = await this.authService.authorizeAndFilterReadResponse({
                         operation: 'search-system',
                         userIdentity: res.locals.userIdentity,
@@ -102,7 +102,7 @@ export default class RootRoute {
                 '/_history',
                 RouteHelper.wrapAsync(async (req: express.Request, res: express.Response) => {
                     const searchParamQuery = req.query;
-                    const response = await this.rootHandler.globalHistory(searchParamQuery);
+                    const response = await this.rootHandler.globalHistory(searchParamQuery, res.locals.userIdentity);
                     const updatedReadResponse = await this.authService.authorizeAndFilterReadResponse({
                         operation: 'history-system',
                         userIdentity: res.locals.userIdentity,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2111,10 +2111,10 @@ fb-watchman@^2.0.0:
   dependencies:
     bser "2.1.1"
 
-fhir-works-on-aws-interface@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/fhir-works-on-aws-interface/-/fhir-works-on-aws-interface-5.0.0.tgz#b22a02ef7277836a4c73638abd6ef4647577c6dc"
-  integrity sha512-/zHOibdUPXGIUy/p+aA1xqVkJr/NQb4h9GWUAtefhBJcO4OWuBkyqKBKSJtsuATiPWMe/4YSTo9lrRNY7RrH1g==
+fhir-works-on-aws-interface@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/fhir-works-on-aws-interface/-/fhir-works-on-aws-interface-6.0.1.tgz#64fb2d471712b3521ca17aced682c8dcfda798f4"
+  integrity sha512-3d++FyAFdiry7XsIfXp/CGfP2QFfnarDgFVUic9WozQA64bTMASqAGK6jfNXZS6isHyY2sK3mILbM6hsHrMt1A==
 
 figures@^3.0.0:
   version "3.2.0"


### PR DESCRIPTION
Issue #, if available:

Description of changes:
Using the method `getSearchFilterBasedOnIdentity` from `Auth` package to add pre SearchFilters to these 4 operations: `search-type`, `history-type`, `search-system`, `history-system`.

This allows us to only search for resources that a requester has access to.



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.