### PR TITLE
feat: use search getCapabilities to build capability statement

### DIFF
--- a/sampleData/r4FhirConfigGeneric.ts
+++ b/sampleData/r4FhirConfigGeneric.ts
@@ -1,6 +1,22 @@
-import { FhirConfig, stubs } from 'fhir-works-on-aws-interface';
+import {
+    Authorization,
+    BulkDataAccess,
+    Bundle,
+    FhirConfig,
+    History,
+    Persistence,
+    Search,
+    stubs as fwoaStubs,
+} from 'fhir-works-on-aws-interface';
 
-const config: FhirConfig = {
+const config = (stubs: {
+    bundle: Bundle;
+    search: Search;
+    history: History;
+    passThroughAuthz: Authorization;
+    persistence: Persistence;
+    bulkDataAccess: BulkDataAccess;
+}): FhirConfig => ({
     configVersion: 1,
     productInfo: {
         orgName: 'Organization Name',
@@ -29,6 +45,10 @@ const config: FhirConfig = {
             typeHistory: stubs.history,
         },
     },
+});
+
+const configFn = (overrideStubs?: any) => {
+    return config({ ...fwoaStubs, ...overrideStubs });
 };
 
-export default config;
+export default configFn;

--- a/sampleData/r4FhirConfigNoGeneric.ts
+++ b/sampleData/r4FhirConfigNoGeneric.ts
@@ -1,6 +1,22 @@
-import { FhirConfig, stubs } from 'fhir-works-on-aws-interface';
+import {
+    Authorization,
+    BulkDataAccess,
+    Bundle,
+    FhirConfig,
+    History,
+    Persistence,
+    Search,
+    stubs as fwoaStubs,
+} from 'fhir-works-on-aws-interface';
 
-const config: FhirConfig = {
+const config = (stubs: {
+    bundle: Bundle;
+    search: Search;
+    history: History;
+    passThroughAuthz: Authorization;
+    persistence: Persistence;
+    bulkDataAccess: BulkDataAccess;
+}): FhirConfig => ({
     configVersion: 1,
     productInfo: {
         orgName: 'Organization Name',
@@ -54,6 +70,10 @@ const config: FhirConfig = {
             },
         },
     },
+});
+
+const configFn = (overrideStubs?: any) => {
+    return config({ ...fwoaStubs, ...overrideStubs });
 };
 
-export default config;
+export default configFn;

--- a/sampleData/r4FhirConfigWithExclusions.ts
+++ b/sampleData/r4FhirConfigWithExclusions.ts
@@ -1,6 +1,22 @@
-import { FhirConfig, stubs } from 'fhir-works-on-aws-interface';
+import {
+    Authorization,
+    BulkDataAccess,
+    Bundle,
+    FhirConfig,
+    History,
+    Persistence,
+    Search,
+    stubs as fwoaStubs,
+} from 'fhir-works-on-aws-interface';
 
-const config: FhirConfig = {
+const config = (stubs: {
+    bundle: Bundle;
+    search: Search;
+    history: History;
+    passThroughAuthz: Authorization;
+    persistence: Persistence;
+    bulkDataAccess: BulkDataAccess;
+}): FhirConfig => ({
     configVersion: 1,
     productInfo: {
         orgName: 'Organization Name',
@@ -49,6 +65,10 @@ const config: FhirConfig = {
             },
         },
     },
+});
+
+const configFn = (overrideStubs?: any) => {
+    return config({ ...fwoaStubs, ...overrideStubs });
 };
 
-export default config;
+export default configFn;

--- a/sampleData/stu3FhirConfigWithExclusions.ts
+++ b/sampleData/stu3FhirConfigWithExclusions.ts
@@ -1,6 +1,22 @@
-import { FhirConfig, stubs } from 'fhir-works-on-aws-interface';
+import {
+    Authorization,
+    BulkDataAccess,
+    Bundle,
+    FhirConfig,
+    History,
+    Persistence,
+    Search,
+    stubs as fwoaStubs,
+} from 'fhir-works-on-aws-interface';
 
-const config: FhirConfig = {
+const config = (stubs: {
+    bundle: Bundle;
+    search: Search;
+    history: History;
+    passThroughAuthz: Authorization;
+    persistence: Persistence;
+    bulkDataAccess: BulkDataAccess;
+}): FhirConfig => ({
     configVersion: 1,
     productInfo: {
         orgName: 'Organization Name',
@@ -37,6 +53,10 @@ const config: FhirConfig = {
             typeHistory: stubs.history,
         },
     },
+});
+
+const configFn = (overrideStubs?: any) => {
+    return config({ ...fwoaStubs, ...overrideStubs });
 };
 
-export default config;
+export default configFn;

--- a/src/router/__mocks__/elasticSearchService.ts
+++ b/src/router/__mocks__/elasticSearchService.ts
@@ -1,4 +1,10 @@
-import { Search, SearchResponse, GlobalSearchRequest, TypeSearchRequest } from 'fhir-works-on-aws-interface';
+import {
+    Search,
+    SearchResponse,
+    GlobalSearchRequest,
+    TypeSearchRequest,
+    SearchCapabilityStatement,
+} from 'fhir-works-on-aws-interface';
 
 const ElasticSearchService: Search = class {
     /*
@@ -18,6 +24,10 @@ const ElasticSearchService: Search = class {
 
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     static globalSearch(request: GlobalSearchRequest): Promise<SearchResponse> {
+        throw new Error('Method not implemented.');
+    }
+
+    static async getCapabilities(): Promise<SearchCapabilityStatement> {
         throw new Error('Method not implemented.');
     }
 };

--- a/src/router/bundle/bundleHandler.test.ts
+++ b/src/router/bundle/bundleHandler.test.ts
@@ -318,7 +318,7 @@ const getSupportedGenericResources = (
     supportedResources: string[],
     fhirVersion: FhirVersion,
 ): string[] => {
-    const customFhirConfig = clone(r4FhirConfigGeneric());
+    const customFhirConfig = r4FhirConfigGeneric();
     customFhirConfig.profile.genericResource = genRes;
     const configHandler = new ConfigHandler(customFhirConfig, supportedResources);
     return configHandler.getGenericResources(fhirVersion);

--- a/src/router/bundle/bundleHandler.test.ts
+++ b/src/router/bundle/bundleHandler.test.ts
@@ -318,7 +318,7 @@ const getSupportedGenericResources = (
     supportedResources: string[],
     fhirVersion: FhirVersion,
 ): string[] => {
-    const customFhirConfig = clone(r4FhirConfigGeneric);
+    const customFhirConfig = clone(r4FhirConfigGeneric());
     customFhirConfig.profile.genericResource = genRes;
     const configHandler = new ConfigHandler(customFhirConfig, supportedResources);
     return configHandler.getGenericResources(fhirVersion);

--- a/src/router/metadata/cap.rest.resource.template.ts
+++ b/src/router/metadata/cap.rest.resource.template.ts
@@ -73,12 +73,7 @@ export function makeGenericResources(
     return resources;
 }
 
-export async function makeResource(
-    resourceType: string,
-    // operations: TypeOperation[],
-    // searchCapabilityStatement: SearchCapabilityStatement,
-    resource: Resource,
-) {
+export async function makeResource(resourceType: string, resource: Resource) {
     const resourceOperations: any[] = makeOperation(resource.operations);
     const updateCreate: boolean = resource.operations.includes('update');
     const hasTypeSearch: boolean = resource.operations.includes('search-type');

--- a/src/router/metadata/cap.rest.resource.template.ts
+++ b/src/router/metadata/cap.rest.resource.template.ts
@@ -3,13 +3,20 @@
  *  SPDX-License-Identifier: Apache-2.0
  */
 
-import { TypeOperation, SystemOperation } from 'fhir-works-on-aws-interface';
+import {
+    TypeOperation,
+    SystemOperation,
+    SearchCapabilityStatement,
+    SearchCapabilities,
+    Resource,
+} from 'fhir-works-on-aws-interface';
 
 function makeResourceObject(
     resourceType: string,
     resourceOperations: any[],
     updateCreate: boolean,
     hasTypeSearch: boolean,
+    searchCapabilities?: SearchCapabilities,
 ) {
     const result: any = {
         type: resourceType,
@@ -23,15 +30,8 @@ function makeResourceObject(
         conditionalDelete: 'not-supported',
     };
 
-    // TODO: Handle case where user specify exactly which search parameters is supported for each resource
-    if (hasTypeSearch) {
-        result.searchParam = [
-            {
-                name: 'ALL',
-                type: 'composite',
-                documentation: 'Support all fields.',
-            },
-        ];
+    if (hasTypeSearch && searchCapabilities !== undefined) {
+        Object.assign(result, searchCapabilities);
     }
 
     return result;
@@ -47,7 +47,11 @@ export function makeOperation(operations: (TypeOperation | SystemOperation)[]) {
     return resourceOperations;
 }
 
-export function makeGenericResources(fhirResourcesToMake: string[], operations: TypeOperation[]) {
+export function makeGenericResources(
+    fhirResourcesToMake: string[],
+    operations: TypeOperation[],
+    searchCapabilityStatement: SearchCapabilityStatement,
+) {
     const resources: any[] = [];
 
     const resourceOperations: any[] = makeOperation(operations);
@@ -55,18 +59,37 @@ export function makeGenericResources(fhirResourcesToMake: string[], operations: 
     const hasTypeSearch: boolean = operations.includes('search-type');
 
     fhirResourcesToMake.forEach((resourceType: string) => {
-        resources.push(makeResourceObject(resourceType, resourceOperations, updateCreate, hasTypeSearch));
+        resources.push(
+            makeResourceObject(
+                resourceType,
+                resourceOperations,
+                updateCreate,
+                hasTypeSearch,
+                searchCapabilityStatement[resourceType],
+            ),
+        );
     });
 
     return resources;
 }
 
-export function makeResource(resourceType: string, operations: TypeOperation[]) {
-    const resourceOperations: any[] = makeOperation(operations);
-    const updateCreate: boolean = operations.includes('update');
-    const hasTypeSearch: boolean = operations.includes('search-type');
+export async function makeResource(
+    resourceType: string,
+    // operations: TypeOperation[],
+    // searchCapabilityStatement: SearchCapabilityStatement,
+    resource: Resource,
+) {
+    const resourceOperations: any[] = makeOperation(resource.operations);
+    const updateCreate: boolean = resource.operations.includes('update');
+    const hasTypeSearch: boolean = resource.operations.includes('search-type');
 
-    const resource = makeResourceObject(resourceType, resourceOperations, updateCreate, hasTypeSearch);
+    const capabilities: SearchCapabilityStatement = hasTypeSearch ? await resource.typeSearch.getCapabilities() : {};
 
-    return resource;
+    return makeResourceObject(
+        resourceType,
+        resourceOperations,
+        updateCreate,
+        hasTypeSearch,
+        capabilities[resourceType],
+    );
 }

--- a/src/router/metadata/metadataHandler.test.ts
+++ b/src/router/metadata/metadataHandler.test.ts
@@ -3,7 +3,7 @@
  *  SPDX-License-Identifier: Apache-2.0
  */
 
-import { clone, stubs } from 'fhir-works-on-aws-interface';
+import { stubs } from 'fhir-works-on-aws-interface';
 import MetadataHandler from './metadataHandler';
 import { makeOperation } from './cap.rest.resource.template';
 import r4FhirConfigGeneric from '../../../sampleData/r4FhirConfigGeneric';
@@ -285,6 +285,49 @@ const SUPPORTED_STU3_RESOURCES = [
     'VisionPrescription',
 ];
 
+const overrideStubs = {
+    search: {
+        getCapabilities: async () => ({
+            AllergyIntolerance: {
+                searchParam: [
+                    {
+                        name: 'some-search-field',
+                        type: 'string',
+                        documentation: 'docs for some search field',
+                    },
+                ],
+            },
+            Organization: {
+                searchParam: [
+                    {
+                        name: 'some-search-field',
+                        type: 'string',
+                        documentation: 'docs for some search field',
+                    },
+                ],
+            },
+            Account: {
+                searchParam: [
+                    {
+                        name: 'some-search-field',
+                        type: 'string',
+                        documentation: 'docs for some search field',
+                    },
+                ],
+            },
+            Patient: {
+                searchParam: [
+                    {
+                        name: 'some-search-field',
+                        type: 'string',
+                        documentation: 'docs for some search field',
+                    },
+                ],
+            },
+        }),
+    },
+};
+
 describe('ERROR: test cases', () => {
     beforeEach(() => {
         // Ensures that for each test, we test the assertions in the catch block
@@ -292,7 +335,10 @@ describe('ERROR: test cases', () => {
     });
     test('STU3: Asking for V4 when only supports V3', async () => {
         // BUILD
-        const configHandler: ConfigHandler = new ConfigHandler(stu3FhirConfigWithExclusions, SUPPORTED_STU3_RESOURCES);
+        const configHandler: ConfigHandler = new ConfigHandler(
+            stu3FhirConfigWithExclusions(),
+            SUPPORTED_STU3_RESOURCES,
+        );
         const metadataHandler: MetadataHandler = new MetadataHandler(configHandler);
         try {
             // OPERATE
@@ -307,7 +353,10 @@ describe('ERROR: test cases', () => {
 
     test('R4: Asking for V3 when only supports V4', async () => {
         // BUILD
-        const configHandler: ConfigHandler = new ConfigHandler(r4FhirConfigGeneric, SUPPORTED_R4_RESOURCES);
+        const configHandler: ConfigHandler = new ConfigHandler(
+            r4FhirConfigGeneric(overrideStubs),
+            SUPPORTED_R4_RESOURCES,
+        );
         const metadataHandler: MetadataHandler = new MetadataHandler(configHandler);
         try {
             // OPERATE
@@ -322,10 +371,12 @@ describe('ERROR: test cases', () => {
 });
 
 test('STU3: FHIR Config V3 with 2 exclusions and search', async () => {
-    const configHandler: ConfigHandler = new ConfigHandler(stu3FhirConfigWithExclusions, SUPPORTED_STU3_RESOURCES);
+    const config = stu3FhirConfigWithExclusions(overrideStubs);
+    const supportedGenericResources = ['AllergyIntolerance', 'Organization', 'Account', 'Patient'];
+    const configHandler: ConfigHandler = new ConfigHandler(config, supportedGenericResources);
     const metadataHandler: MetadataHandler = new MetadataHandler(configHandler, true);
     const response = await metadataHandler.capabilities({ fhirVersion: '3.0.1', mode: 'full' });
-    const { genericResource } = stu3FhirConfigWithExclusions.profile;
+    const { genericResource } = config.profile;
     const excludedResources = genericResource ? genericResource.excludedSTU3Resources || [] : [];
     const expectedSubset = {
         acceptUnknown: 'no',
@@ -334,9 +385,7 @@ test('STU3: FHIR Config V3 with 2 exclusions and search', async () => {
     expect(response.resource).toBeDefined();
     expect(response.resource).toMatchObject(expectedSubset);
     expect(response.resource.rest.length).toEqual(1);
-    expect(response.resource.rest[0].resource.length).toEqual(
-        SUPPORTED_STU3_RESOURCES.length - excludedResources.length,
-    );
+    expect(response.resource.rest[0].resource.length).toEqual(3); // only AllergyIntolerance is excluded out of the 4 supportedGenericResources for this test
     expect(response.resource.rest[0].security.cors).toBeTruthy();
     // see if just READ is chosen for generic
     let isExcludedResourceFound = false;
@@ -349,9 +398,9 @@ test('STU3: FHIR Config V3 with 2 exclusions and search', async () => {
             updateCreate: true,
             searchParam: [
                 {
-                    name: 'ALL',
-                    type: 'composite',
-                    documentation: 'Support all fields.',
+                    name: 'some-search-field',
+                    type: 'string',
+                    documentation: 'docs for some search field',
                 },
             ],
         };
@@ -359,16 +408,14 @@ test('STU3: FHIR Config V3 with 2 exclusions and search', async () => {
     });
     expect(isExcludedResourceFound).toBeFalsy();
 
-    expect(response.resource.rest[0].interaction).toEqual(
-        makeOperation(stu3FhirConfigWithExclusions.profile.systemOperations),
-    );
+    expect(response.resource.rest[0].interaction).toEqual(makeOperation(config.profile.systemOperations));
     expect(response.resource.rest[0].searchParam).toBeUndefined();
     expect(stu3Validator.validate('CapabilityStatement', response.resource)).toEqual({
         message: 'Success',
     });
 });
 test('R4: FHIR Config V4 without search', async () => {
-    const configHandler: ConfigHandler = new ConfigHandler(r4FhirConfigGeneric, SUPPORTED_R4_RESOURCES);
+    const configHandler: ConfigHandler = new ConfigHandler(r4FhirConfigGeneric(overrideStubs), SUPPORTED_R4_RESOURCES);
     const metadataHandler: MetadataHandler = new MetadataHandler(configHandler);
     const response = await metadataHandler.capabilities({ fhirVersion: '4.0.1', mode: 'full' });
     expect(response.resource).toBeDefined();
@@ -383,7 +430,9 @@ test('R4: FHIR Config V4 without search', async () => {
         updateCreate: true,
     };
     expect(response.resource.rest[0].resource[0]).toMatchObject(expectedResourceSubset);
-    expect(response.resource.rest[0].interaction).toEqual(makeOperation(r4FhirConfigGeneric.profile.systemOperations));
+    expect(response.resource.rest[0].interaction).toEqual(
+        makeOperation(r4FhirConfigGeneric(overrideStubs).profile.systemOperations),
+    );
     expect(response.resource.rest[0].searchParam).toBeUndefined();
     expect(r4Validator.validate('CapabilityStatement', response.resource)).toEqual({
         message: 'Success',
@@ -391,10 +440,11 @@ test('R4: FHIR Config V4 without search', async () => {
 });
 
 test('R4: FHIR Config V4 with 3 exclusions and AllergyIntollerance special', async () => {
-    const configHandler: ConfigHandler = new ConfigHandler(r4FhirConfigWithExclusions, SUPPORTED_R4_RESOURCES);
+    const config = r4FhirConfigWithExclusions(overrideStubs);
+    const configHandler: ConfigHandler = new ConfigHandler(config, SUPPORTED_R4_RESOURCES);
     const metadataHandler: MetadataHandler = new MetadataHandler(configHandler);
     const response = await metadataHandler.capabilities({ fhirVersion: '4.0.1', mode: 'full' });
-    const { genericResource } = r4FhirConfigWithExclusions.profile;
+    const { genericResource } = config.profile;
     const excludedResources = genericResource ? genericResource.excludedR4Resources || [] : [];
     expect(response.resource).toBeDefined();
     expect(response.resource.acceptUnknown).toBeUndefined();
@@ -426,9 +476,7 @@ test('R4: FHIR Config V4 with 3 exclusions and AllergyIntollerance special', asy
         expect(resource.searchParam).toBeUndefined();
     });
     expect(isExclusionFound).toBeFalsy();
-    expect(response.resource.rest[0].interaction).toEqual(
-        makeOperation(r4FhirConfigWithExclusions.profile.systemOperations),
-    );
+    expect(response.resource.rest[0].interaction).toEqual(makeOperation(config.profile.systemOperations));
     expect(response.resource.rest[0].searchParam).toBeDefined();
     expect(r4Validator.validate('CapabilityStatement', response.resource)).toEqual({
         message: 'Success',
@@ -436,9 +484,10 @@ test('R4: FHIR Config V4 with 3 exclusions and AllergyIntollerance special', asy
 });
 
 test('R4: FHIR Config V4 no generic set-up & mix of STU3 & R4', async () => {
-    const configHandler: ConfigHandler = new ConfigHandler(r4FhirConfigNoGeneric, SUPPORTED_R4_RESOURCES);
+    const config = r4FhirConfigNoGeneric(overrideStubs);
+    const configHandler: ConfigHandler = new ConfigHandler(config, SUPPORTED_R4_RESOURCES);
     const metadataHandler: MetadataHandler = new MetadataHandler(configHandler);
-    const configResource: any = r4FhirConfigNoGeneric.profile.resources;
+    const configResource: any = config.profile.resources;
     const response = await metadataHandler.capabilities({ fhirVersion: '4.0.1', mode: 'full' });
     expect(response.resource).toBeDefined();
     expect(response.resource.acceptUnknown).toBeUndefined();
@@ -465,7 +514,7 @@ test('R4: FHIR Config V4 no generic set-up & mix of STU3 & R4', async () => {
     });
     expect(isSTU3ResourceFound).toBeFalsy();
     expect(response.resource.rest[0].interaction).toEqual(
-        makeOperation(r4FhirConfigNoGeneric.profile.systemOperations),
+        makeOperation(r4FhirConfigNoGeneric().profile.systemOperations),
     );
     expect(response.resource.rest[0].searchParam).toBeDefined();
     expect(r4Validator.validate('CapabilityStatement', response.resource)).toEqual({
@@ -473,7 +522,7 @@ test('R4: FHIR Config V4 no generic set-up & mix of STU3 & R4', async () => {
     });
 });
 test('R4: FHIR Config V4 with bulkDataAccess', async () => {
-    const r4ConfigWithBulkDataAccess = clone(r4FhirConfigGeneric);
+    const r4ConfigWithBulkDataAccess = r4FhirConfigGeneric(overrideStubs);
     r4ConfigWithBulkDataAccess.profile.bulkDataAccess = stubs.bulkDataAccess;
     const configHandler: ConfigHandler = new ConfigHandler(r4ConfigWithBulkDataAccess, SUPPORTED_R4_RESOURCES);
     const metadataHandler: MetadataHandler = new MetadataHandler(configHandler);
@@ -494,7 +543,7 @@ test('R4: FHIR Config V4 with bulkDataAccess', async () => {
 });
 
 test('R4: FHIR Config V4 without bulkDataAccess', async () => {
-    const configHandler: ConfigHandler = new ConfigHandler(r4FhirConfigGeneric, SUPPORTED_R4_RESOURCES);
+    const configHandler: ConfigHandler = new ConfigHandler(r4FhirConfigGeneric(overrideStubs), SUPPORTED_R4_RESOURCES);
     const metadataHandler: MetadataHandler = new MetadataHandler(configHandler);
     const response = await metadataHandler.capabilities({ fhirVersion: '4.0.1', mode: 'full' });
 
@@ -502,7 +551,7 @@ test('R4: FHIR Config V4 without bulkDataAccess', async () => {
 });
 
 test('R4: FHIR Config V4 with all Oauth Policy endpoints', async () => {
-    const r4ConfigWithOauthEndpoints = clone(r4FhirConfigGeneric);
+    const r4ConfigWithOauthEndpoints = r4FhirConfigGeneric(overrideStubs);
     r4ConfigWithOauthEndpoints.auth.strategy = {
         service: 'OAuth',
         oauthPolicy: {
@@ -566,7 +615,7 @@ test('R4: FHIR Config V4 with all Oauth Policy endpoints', async () => {
 });
 
 test('R4: FHIR Config V4 with some Oauth Policy endpoints', async () => {
-    const r4ConfigWithOauthEndpoints = clone(r4FhirConfigGeneric);
+    const r4ConfigWithOauthEndpoints = r4FhirConfigGeneric(overrideStubs);
     r4ConfigWithOauthEndpoints.auth.strategy = {
         service: 'OAuth',
         oauthPolicy: {
@@ -615,7 +664,7 @@ test('R4: FHIR Config V4 with some Oauth Policy endpoints', async () => {
 });
 
 test('R4: FHIR Config V4 with all productInfo params', async () => {
-    const r4ConfigWithAllProductInfo = clone(r4FhirConfigGeneric);
+    const r4ConfigWithAllProductInfo = r4FhirConfigGeneric(overrideStubs);
     r4ConfigWithAllProductInfo.productInfo = {
         orgName: 'Organization Name',
         productVersion: '1.0.0',

--- a/src/router/metadata/metadataHandler.ts
+++ b/src/router/metadata/metadataHandler.ts
@@ -21,23 +21,27 @@ export default class MetadataHandler implements Capabilities {
         this.hasCORSEnabled = hasCORSEnabled;
     }
 
-    private generateResources(fhirVersion: FhirVersion) {
+    private async generateResources(fhirVersion: FhirVersion) {
         const specialResourceTypes = this.configHandler.getSpecialResourceTypes(fhirVersion);
         let generatedResources = [];
         if (this.configHandler.config.profile.genericResource) {
             const generatedResourcesTypes = this.configHandler.getGenericResources(fhirVersion, specialResourceTypes);
+            // this.configHandler.config.profile.genericResource.typeSearch.
             generatedResources = makeGenericResources(
                 generatedResourcesTypes,
                 this.configHandler.getGenericOperations(fhirVersion),
+                await this.configHandler.config.profile.genericResource.typeSearch.getCapabilities(),
             );
         }
 
         // Add the special resources
-        specialResourceTypes.forEach((resourceType: string) => {
-            generatedResources.push(
-                makeResource(resourceType, this.configHandler.getSpecialResourceOperations(resourceType, fhirVersion)),
-            );
-        });
+        generatedResources.push(
+            ...(await Promise.all(
+                specialResourceTypes.map(resourceType =>
+                    makeResource(resourceType, this.configHandler.config.profile.resources![resourceType]),
+                ),
+            )),
+        );
 
         return generatedResources;
     }
@@ -49,7 +53,7 @@ export default class MetadataHandler implements Capabilities {
             throw new createError.NotFound(`FHIR version ${request.fhirVersion} is not supported`);
         }
 
-        const generatedResources = this.generateResources(request.fhirVersion);
+        const generatedResources = await this.generateResources(request.fhirVersion);
         const security = makeSecurity(auth, this.hasCORSEnabled);
         const rest = makeRest(generatedResources, security, profile.systemOperations, !!profile.bulkDataAccess);
         const capStatement = makeStatement(rest, productInfo, server.url, request.fhirVersion);

--- a/src/router/metadata/metadataHandler.ts
+++ b/src/router/metadata/metadataHandler.ts
@@ -26,7 +26,6 @@ export default class MetadataHandler implements Capabilities {
         let generatedResources = [];
         if (this.configHandler.config.profile.genericResource) {
             const generatedResourcesTypes = this.configHandler.getGenericResources(fhirVersion, specialResourceTypes);
-            // this.configHandler.config.profile.genericResource.typeSearch.
             generatedResources = makeGenericResources(
                 generatedResourcesTypes,
                 this.configHandler.getGenericOperations(fhirVersion),


### PR DESCRIPTION
Description of changes:

Call the new `Search.getCapabilities` method and merge it's output into the overall capability statement

An example of a fragment of the `/metadata` response would be:
```js
{
    "type": "Patient",
    "interaction": [
        {
            "code": "create"
        },
        {
            "code": "read"
        },
        {
            "code": "update"
        },
        {
            "code": "delete"
        },
        {
            "code": "vread"
        },
        {
            "code": "search-type"
        }
    ],
    "versioning": "versioned",
    "readHistory": false,
    "updateCreate": true,
    "conditionalCreate": false,
    "conditionalRead": "not-supported",
    "conditionalUpdate": false,
    "conditionalDelete": "not-supported",
    "searchParam": [
        {
            "name": "birthdate",
            "definition": "http://hl7.org/fhir/SearchParameter/individual-birthdate",
            "type": "date",
            "documentation": "Multiple Resources: \r\n\r\n* [Patient](patient.html): The patient's date of birth\r\n* [Person](person.html): The person's date of birth\r\n* [RelatedPerson](relatedperson.html): The Related Person's date of birth\r\n"
        },
        {
            "name": "death-date",
            "definition": "http://hl7.org/fhir/SearchParameter/Patient-death-date",
            "type": "date",
            "documentation": "The date of death has been provided and satisfies this search value"
        },
        {
            "name": "email",
            "definition": "http://hl7.org/fhir/SearchParameter/individual-email",
            "type": "token",
            "documentation": "Multiple Resources: \r\n\r\n* [Patient](patient.html): A value in an email contact\r\n* [Person](person.html): A value in an email contact\r\n* [Practitioner](practitioner.html): A value in an email contact\r\n* [PractitionerRole](practitionerrole.html): A value in an email contact\r\n* [RelatedPerson](relatedperson.html): A value in an email contact\r\n"
        },
        {
            "name": "_id",
            "definition": "http://hl7.org/fhir/SearchParameter/Resource-id",
            "type": "token",
            "documentation": "Logical id of this artifact"
        },
        ...
    ],
    "searchInclude": [
        "*",
        "Patient:general-practitioner",
        "Patient:link",
        "Patient:organization"
    ],
    "searchRevInclude": [
        "*",
        "Account:patient",
        "Account:subject",
        "ActivityDefinition:composed-of",
        "ActivityDefinition:depends-on",
        "ActivityDefinition:derived-from",
        "ActivityDefinition:predecessor",
        "ActivityDefinition:successor",
        ...
    ]
}

```

Note: There are a bunch of minor changes in tests since previously there was no way to control the stubs used in unit tests.
Also, using `clone` on a `FhirConfig` object never actually worked since `clone` is based on `JSON.stringify` and it cannot handle the FwoA Interface objects (i.e. `Search`)

Related PRs:
- https://github.com/awslabs/fhir-works-on-aws-interface/pull/42
- https://github.com/awslabs/fhir-works-on-aws-search-es/pull/35

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.