### PR TITLE
fix: use correct SMART url in Cap Statement

### DIFF
--- a/src/router/metadata/cap.rest.security.template.ts
+++ b/src/router/metadata/cap.rest.security.template.ts
@@ -61,7 +61,7 @@ export default function makeSecurity(authConfig: Auth, hasCORSEnabled: boolean =
                 ...{
                     extension: [
                         {
-                            url: 'https://www.hl7.org/fhir/smart-app-launch/StructureDefinition-oauth-uris.html',
+                            url: 'http://fhir-registry.smarthealthit.org/StructureDefinition/oauth-uris',
                             extension,
                         },
                     ],

--- a/src/router/metadata/metadataHandler.test.ts
+++ b/src/router/metadata/metadataHandler.test.ts
@@ -598,7 +598,7 @@ test('R4: FHIR Config V4 with all Oauth Policy endpoints', async () => {
                         valueUri: 'http://fhir-server.com/register',
                     },
                 ],
-                url: 'https://www.hl7.org/fhir/smart-app-launch/StructureDefinition-oauth-uris.html',
+                url: 'http://fhir-registry.smarthealthit.org/StructureDefinition/oauth-uris',
             },
         ],
         service: [
@@ -647,7 +647,7 @@ test('R4: FHIR Config V4 with some Oauth Policy endpoints', async () => {
                         valueUri: 'http://fhir-server.com/manage',
                     },
                 ],
-                url: 'https://www.hl7.org/fhir/smart-app-launch/StructureDefinition-oauth-uris.html',
+                url: 'http://fhir-registry.smarthealthit.org/StructureDefinition/oauth-uris',
             },
         ],
         service: [


### PR DESCRIPTION
According to [inferno](https://inferno.healthit.gov/community/); http://fhir-registry.smarthealthit.org/StructureDefinition/oauth-uris is the right extension (and will fail one of their tests if it is not correct)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.