### PR TITLE
refactor: remove extra messaging in InvalidResourceError error handler

### DIFF
--- a/src/router/bundle/bundleHandler.test.ts
+++ b/src/router/bundle/bundleHandler.test.ts
@@ -427,7 +427,11 @@ describe('ERROR Cases: Validation of Bundle request', () => {
 
             await bundleHandlerR4.processTransaction(bundleRequestJSON, practitionerDecoded);
         } catch (e) {
-            expect(e).toEqual(new InvalidResourceError('data.entry[0].request should NOT have additional properties'));
+            expect(e).toEqual(
+                new InvalidResourceError(
+                    'Failed to parse request body as JSON resource. Error was: data.entry[0].request should NOT have additional properties',
+                ),
+            );
         }
     });
 
@@ -450,7 +454,11 @@ describe('ERROR Cases: Validation of Bundle request', () => {
 
             await bundleHandlerSTU3.processTransaction(bundleRequestJSON, practitionerDecoded);
         } catch (e) {
-            expect(e).toEqual(new InvalidResourceError("data should have required property 'resourceType'"));
+            expect(e).toEqual(
+                new InvalidResourceError(
+                    "Failed to parse request body as JSON resource. Error was: data should have required property 'resourceType'",
+                ),
+            );
         }
     });
 

--- a/src/router/handlers/resourceHandler.test.ts
+++ b/src/router/handlers/resourceHandler.test.ts
@@ -246,7 +246,7 @@ describe('ERROR CASES: Testing create, read, update, delete of resources', () =>
             // CHECK
             expect(e).toEqual(
                 new InvalidResourceError(
-                    "data.text should have required property 'div', data.gender should be equal to one of the allowed values",
+                    "Failed to parse request body as JSON resource. Error was: data.text should have required property 'div', data.gender should be equal to one of the allowed values",
                 ),
             );
         }
@@ -273,7 +273,7 @@ describe('ERROR CASES: Testing create, read, update, delete of resources', () =>
             // CHECK
             expect(e).toEqual(
                 new InvalidResourceError(
-                    "data.text should have required property 'div', data.gender should be equal to one of the allowed values",
+                    "Failed to parse request body as JSON resource. Error was: data.text should have required property 'div', data.gender should be equal to one of the allowed values",
                 ),
             );
         }

--- a/src/router/handlers/resourceHandler.ts
+++ b/src/router/handlers/resourceHandler.ts
@@ -3,16 +3,7 @@
  *  SPDX-License-Identifier: Apache-2.0
  */
 
-import {
-    Search,
-    History,
-    Persistence,
-    FhirVersion,
-    Authorization,
-    KeyValueMap,
-    isInvalidResourceError,
-} from 'fhir-works-on-aws-interface';
-import createError from 'http-errors';
+import { Search, History, Persistence, FhirVersion, Authorization, KeyValueMap } from 'fhir-works-on-aws-interface';
 import BundleGenerator from '../bundle/bundleGenerator';
 import CrudHandlerInterface from './CrudHandlerInterface';
 import OperationsGenerator from '../operationsGenerator';

--- a/src/router/handlers/resourceHandler.ts
+++ b/src/router/handlers/resourceHandler.ts
@@ -50,15 +50,8 @@ export default class ResourceHandler implements CrudHandlerInterface {
     async create(resourceType: string, resource: any) {
         this.validator.validate(resourceType, resource);
 
-        try {
-            const createResponse = await this.dataService.createResource({ resourceType, resource });
-            return createResponse.resource;
-        } catch (e) {
-            if (isInvalidResourceError(e)) {
-                throw new createError.BadRequest(e.message);
-            }
-            throw e;
-        }
+        const createResponse = await this.dataService.createResource({ resourceType, resource });
+        return createResponse.resource;
     }
 
     async update(resourceType: string, id: string, resource: any) {

--- a/src/router/routes/errorHandling.ts
+++ b/src/router/routes/errorHandling.ts
@@ -28,7 +28,7 @@ export const applicationErrorMapper = (
         return;
     }
     if (isInvalidResourceError(err)) {
-        next(new createError.BadRequest(`Failed to parse request body as JSON resource. Error was: ${err.message}`));
+        next(new createError.BadRequest(err.message));
         return;
     }
     if (isUnauthorizedError(err)) {

--- a/src/router/validation/validator.test.ts
+++ b/src/router/validation/validator.test.ts
@@ -19,7 +19,7 @@ describe('Validating V4 resources', () => {
     test('Show error when validating invalid resource', () => {
         expect(() => validatorV4.validate('Patient', invalidPatient)).toThrowError(
             new InvalidResourceError(
-                "data.text should have required property 'div', data.gender should be equal to one of the allowed values",
+                "Failed to parse request body as JSON resource. Error was: data.text should have required property 'div', data.gender should be equal to one of the allowed values",
             ),
         );
     });
@@ -27,7 +27,7 @@ describe('Validating V4 resources', () => {
     test('Show error when checking for wrong version of FHIR resource', () => {
         expect(() => validatorV4.validate('Account', validV3Account)).toThrowError(
             new InvalidResourceError(
-                'data should NOT have additional properties, data should NOT have additional properties, data should NOT have additional properties, data.subject should be array',
+                'Failed to parse request body as JSON resource. Error was: data should NOT have additional properties, data should NOT have additional properties, data should NOT have additional properties, data.subject should be array',
             ),
         );
     });
@@ -64,7 +64,7 @@ describe('Validating V3 resources', () => {
     test('Show error when validating invalid resource', () => {
         expect(() => validatorV3.validate('Patient', invalidPatient)).toThrowError(
             new InvalidResourceError(
-                "data.text should have required property 'div', data.gender should be equal to one of the allowed values",
+                "Failed to parse request body as JSON resource. Error was: data.text should have required property 'div', data.gender should be equal to one of the allowed values",
             ),
         );
     });

--- a/src/router/validation/validator.ts
+++ b/src/router/validation/validator.ts
@@ -33,7 +33,9 @@ export default class Validator {
         const referenceName = `#/definitions/${definitionName}`;
         const result = this.ajv.validate(referenceName, data);
         if (!result) {
-            throw new InvalidResourceError(this.ajv.errorsText());
+            throw new InvalidResourceError(
+                `Failed to parse request body as JSON resource. Error was: ${this.ajv.errorsText()}`,
+            );
         }
         return { message: 'Success' };
     }


### PR DESCRIPTION
Issue #, if available:

Description of changes:
fix: If creating a new resource failed because of InvalidResource, propogate that error message to user as a 400 error

Related PR: 
https://github.com/awslabs/fhir-works-on-aws-persistence-ddb/pull/51

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.