### PR TITLE
fix: Relax validation rules before a patch can be applied

### DIFF
--- a/src/router/routes/genericResourceRoute.ts
+++ b/src/router/routes/genericResourceRoute.ts
@@ -218,7 +218,7 @@ export default class GenericResourceRoute {
                     const { id } = req.params;
                     const { body } = req;
 
-                    if (body.id === null || body.id !== id) {
+                    if (body.id && body.id !== id) {
                         throw new createError.BadRequest(
                             `Can not update resource with ID[${id}], while the given request payload has an ID[${body.id}]`,
                         );


### PR DESCRIPTION
fhir spec specifies the supported patch content-types at https://www.hl7.org/fhir/http.html#patch

The structure of each patch type is dependent on the content-type.
`application/json-patch+json` patch type is being rejected due to very strict validation rules

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.