### PR TITLE
fix: handle POST bundle with no fullUrl and relative refs

### DIFF
--- a/src/router/bundle/bundleParser.test.ts
+++ b/src/router/bundle/bundleParser.test.ts
@@ -769,6 +769,85 @@ describe('parseResource', () => {
             expect(actualRequests).toEqual(expectedRequests);
         });
 
+        test('POST with missing fullUrl and relative references', async () => {
+            const bundleRequestJson = {
+                resourceType: 'Bundle',
+                type: 'transaction',
+                entry: [
+                    {
+                        resource: {
+                            resourceType: 'Observation',
+                            status: 'final',
+                            code: {
+                                coding: [
+                                    {
+                                        code: 'LQA',
+                                        display: 'display value for LQA',
+                                    },
+                                ],
+                            },
+                            subject: {
+                                reference: 'Patient/111',
+                            },
+                            device: {
+                                reference: 'Device/222',
+                            },
+                            effectiveDateTime: '2021-01-09T20:00:06Z',
+                            valueQuantity: {
+                                unit: 'cm',
+                                value: 170,
+                            },
+                        },
+                        request: {
+                            method: 'POST',
+                            url: 'Observation',
+                        },
+                    },
+                ],
+            };
+
+            const batchReadWriteRequest = await BundleParser.parseResource(
+                bundleRequestJson,
+                DynamoDbDataService,
+                serverUrl,
+            );
+            expect(batchReadWriteRequest).toHaveLength(1);
+            expect(batchReadWriteRequest[0]).toMatchInlineSnapshot(
+                { id: expect.stringMatching(uuidRegExp) },
+                `
+                Object {
+                  "fullUrl": "",
+                  "id": StringMatching /\\\\w\\{8\\}-\\\\w\\{4\\}-\\\\w\\{4\\}-\\\\w\\{4\\}-\\\\w\\{12\\}/,
+                  "operation": "create",
+                  "resource": Object {
+                    "code": Object {
+                      "coding": Array [
+                        Object {
+                          "code": "LQA",
+                          "display": "display value for LQA",
+                        },
+                      ],
+                    },
+                    "device": Object {
+                      "reference": "Device/222",
+                    },
+                    "effectiveDateTime": "2021-01-09T20:00:06Z",
+                    "resourceType": "Observation",
+                    "status": "final",
+                    "subject": Object {
+                      "reference": "Patient/111",
+                    },
+                    "valueQuantity": Object {
+                      "unit": "cm",
+                      "value": 170,
+                    },
+                  },
+                  "resourceType": "Observation",
+                }
+            `,
+            );
+        });
+
         test('Circular references. An Observation with a reference to a Procedure. That Procedure referencing the Observation.', async () => {
             const bundleRequestJson = {
                 resourceType: 'Bundle',

--- a/src/router/bundle/bundleParser.ts
+++ b/src/router/bundle/bundleParser.ts
@@ -335,7 +335,7 @@ export default class BundleParser {
                 let rootUrl = fullUrlMatch[1];
                 // If the reference doesn't have a urlRoot, check if the entry's fullUrl has a urlRoot
                 if (rootUrl === undefined) {
-                    if (entry.fullUrl.length > 0 && entry.fullUrl.match(captureFullUrlParts)) {
+                    if (entry.fullUrl && entry.fullUrl.match(captureFullUrlParts)) {
                         // eslint-disable-next-line prefer-destructuring
                         rootUrl = entry.fullUrl.match(captureFullUrlParts)[1];
                     }


### PR DESCRIPTION
Issue #, if available:
See: https://github.com/awslabs/fhir-works-on-aws-deployment/issues/305

Description of changes:
Some bundle requests were failing with "Cannot read property 'length' of undefined"

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.