### PR TITLE
refactor: consolidate search logic inside ResourceHandler

### DIFF
--- a/src/router/handlers/CrudHandlerInterface.ts
+++ b/src/router/handlers/CrudHandlerInterface.ts
@@ -12,7 +12,7 @@ export default interface CrudHandlerInterface {
     read(resourceType: string, id: string): any;
     vRead(resourceType: string, id: string, vid: string): any;
     delete(resourceType: string, id: string): any;
-    typeSearch(resourceType: string, searchParams: any, allowedResourceTypes: string[], userIdentity: KeyValueMap): any;
+    typeSearch(resourceType: string, searchParams: any, userIdentity: KeyValueMap): any;
     typeHistory(resourceType: string, searchParams: any, userIdentity: KeyValueMap): any;
     instanceHistory(resourceType: string, id: string, searchParams: any, userIdentity: KeyValueMap): any;
 }

--- a/src/router/handlers/resourceHandler.test.ts
+++ b/src/router/handlers/resourceHandler.test.ts
@@ -366,6 +366,11 @@ describe('Testing search', () => {
 
     test('Search for a patient that exist', async () => {
         // BUILD
+
+        stubs.passThroughAuthz.getAllowedResourceTypesForOperation = jest
+            .fn()
+            .mockResolvedValue(['Patient', 'Practitioner']);
+
         const resourceHandler = initializeResourceHandler({
             result: {
                 numberOfResults: 1,
@@ -383,14 +388,13 @@ describe('Testing search', () => {
         });
 
         // OPERATE
-        const searchResponse: any = await resourceHandler.typeSearch(
-            'Patient',
-            { name: 'Henry' },
-            ['Patient', 'Practitioner'],
-            {},
-        );
+        const searchResponse: any = await resourceHandler.typeSearch('Patient', { name: 'Henry' }, {});
 
         // CHECK
+        expect(stubs.passThroughAuthz.getAllowedResourceTypesForOperation).toHaveBeenCalledWith({
+            operation: 'search-type',
+            userIdentity: {},
+        });
         expect(ElasticSearchService.typeSearch).toHaveBeenCalledWith({
             allowedResourceTypes: ['Patient', 'Practitioner'],
             baseUrl: 'https://API_URL.com',
@@ -433,7 +437,7 @@ describe('Testing search', () => {
         });
 
         // OPERATE
-        const searchResponse: any = await resourceHandler.typeSearch('Patient', { name: 'Henry' }, [], {});
+        const searchResponse: any = await resourceHandler.typeSearch('Patient', { name: 'Henry' }, {});
 
         // CHECK
         expect(searchResponse.resourceType).toEqual('Bundle');
@@ -457,7 +461,7 @@ describe('Testing search', () => {
         ElasticSearchService.typeSearch = jest.fn().mockRejectedValue(new Error('Boom!!'));
         try {
             // OPERATE
-            await resourceHandler.typeSearch('Patient', { name: 'Henry' }, [], {});
+            await resourceHandler.typeSearch('Patient', { name: 'Henry' }, {});
         } catch (e) {
             // CHECK
             expect(e).toEqual(new Error('Boom!!'));
@@ -492,7 +496,6 @@ describe('Testing search', () => {
                     [SEARCH_PAGINATION_PARAMS.PAGES_OFFSET]: 0,
                     [SEARCH_PAGINATION_PARAMS.COUNT]: 1,
                 },
-                [],
                 {},
             );
 
@@ -549,7 +552,6 @@ describe('Testing search', () => {
                     [SEARCH_PAGINATION_PARAMS.PAGES_OFFSET]: 1,
                     [SEARCH_PAGINATION_PARAMS.COUNT]: 1,
                 },
-                [],
                 {},
             );
 
@@ -606,7 +608,6 @@ describe('Testing search', () => {
                     [SEARCH_PAGINATION_PARAMS.PAGES_OFFSET]: 1,
                     [SEARCH_PAGINATION_PARAMS.COUNT]: 1,
                 },
-                [],
                 {},
             );
 

--- a/src/router/handlers/resourceHandler.ts
+++ b/src/router/handlers/resourceHandler.ts
@@ -59,12 +59,12 @@ export default class ResourceHandler implements CrudHandlerInterface {
         return patchResponse.resource;
     }
 
-    async typeSearch(
-        resourceType: string,
-        queryParams: any,
-        allowedResourceTypes: string[],
-        userIdentity: KeyValueMap,
-    ) {
+    async typeSearch(resourceType: string, queryParams: any, userIdentity: KeyValueMap) {
+        const allowedResourceTypes = await this.authService.getAllowedResourceTypesForOperation({
+            operation: 'search-type',
+            userIdentity,
+        });
+
         const searchFilters = await this.authService.getSearchFilterBasedOnIdentity({
             userIdentity,
             operation: 'search-type',
@@ -78,13 +78,19 @@ export default class ResourceHandler implements CrudHandlerInterface {
             allowedResourceTypes,
             searchFilters,
         });
-        return BundleGenerator.generateBundle(
+        const bundle = BundleGenerator.generateBundle(
             this.serverUrl,
             queryParams,
             searchResponse.result,
             'searchset',
             resourceType,
         );
+
+        return this.authService.authorizeAndFilterReadResponse({
+            operation: 'search-type',
+            userIdentity,
+            readResponse: bundle,
+        });
     }
 
     async typeHistory(resourceType: string, queryParams: any, userIdentity: KeyValueMap) {

--- a/src/router/routes/genericResourceRoute.ts
+++ b/src/router/routes/genericResourceRoute.ts
@@ -129,23 +129,7 @@ export default class GenericResourceRoute {
 
         if (this.operations.includes('search-type')) {
             const handleSearch = async (res: express.Response, resourceType: string, searchParamQuery: any) => {
-                const allowedResourceTypes = await this.authService.getAllowedResourceTypesForOperation({
-                    operation: 'search-type',
-                    userIdentity: res.locals.userIdentity,
-                });
-
-                const response = await this.handler.typeSearch(
-                    resourceType,
-                    searchParamQuery,
-                    allowedResourceTypes,
-                    res.locals.userIdentity,
-                );
-                const updatedSearchResponse = await this.authService.authorizeAndFilterReadResponse({
-                    operation: 'search-type',
-                    userIdentity: res.locals.userIdentity,
-                    readResponse: response,
-                });
-                return updatedSearchResponse;
+                return this.handler.typeSearch(resourceType, searchParamQuery, res.locals.userIdentity);
             };
             // SEARCH
             this.router.get(


### PR DESCRIPTION
Description of changes:

There are no functional changes. just moving all the search logic into `ResourceHandler.typeSearch` to make it easier to reuse (docref wants to search stuff)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.