### PR TITLE
feat: add US Core $docref implementation

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@types/cors": "^2.8.7",
     "@types/express-serve-static-core": "^4.17.2",
     "ajv": "^6.11.0",
+    "ajv-errors": "^1.0.1",
     "aws-sdk": "^2.856.0",
     "aws-xray-sdk": "^3.2.0",
     "cors": "^2.8.5",

--- a/src/operationDefinitions/USCoreDocRef/convertDocRefParamsToSearchParams.ts
+++ b/src/operationDefinitions/USCoreDocRef/convertDocRefParamsToSearchParams.ts
@@ -6,7 +6,7 @@
 
 import { DocRefParams } from './parseParams';
 
-export const docRefParamsToSearchParams = (docRefParams: DocRefParams) => {
+export const convertDocRefParamsToSearchParams = (docRefParams: DocRefParams) => {
     const { patient, start, end, type, onDemand } = docRefParams;
 
     if (onDemand) {

--- a/src/operationDefinitions/USCoreDocRef/docRefParamsToSearchParams.test.ts
+++ b/src/operationDefinitions/USCoreDocRef/docRefParamsToSearchParams.test.ts
@@ -4,11 +4,11 @@
  *
  */
 
-import { docRefParamsToSearchParams } from './docRefParamsToSearchParams';
+import { convertDocRefParamsToSearchParams } from './convertDocRefParamsToSearchParams';
 
 describe('docRefParamsToSearchParams', () => {
     test('minimal params ', () => {
-        expect(docRefParamsToSearchParams({ patient: 'Patient/1' })).toMatchInlineSnapshot(`
+        expect(convertDocRefParamsToSearchParams({ patient: 'Patient/1' })).toMatchInlineSnapshot(`
             Object {
               "_count": "1",
               "_sort": "-period",
@@ -19,7 +19,7 @@ describe('docRefParamsToSearchParams', () => {
     });
     test('all params ', () => {
         expect(
-            docRefParamsToSearchParams({
+            convertDocRefParamsToSearchParams({
                 patient: 'Patient/1',
                 start: '1990-10-10',
                 end: '1995-10-10',
@@ -43,7 +43,7 @@ describe('docRefParamsToSearchParams', () => {
 
     test('on demand', () => {
         expect(
-            docRefParamsToSearchParams({
+            convertDocRefParamsToSearchParams({
                 patient: 'Patient/1',
                 onDemand: true,
             }),
@@ -56,7 +56,7 @@ describe('docRefParamsToSearchParams', () => {
 
     test('only start', () => {
         expect(
-            docRefParamsToSearchParams({
+            convertDocRefParamsToSearchParams({
                 patient: 'Patient/1',
                 start: '1990',
             }),
@@ -73,7 +73,7 @@ describe('docRefParamsToSearchParams', () => {
 
     test('only end', () => {
         expect(
-            docRefParamsToSearchParams({
+            convertDocRefParamsToSearchParams({
                 patient: 'Patient/1',
                 end: '2000',
             }),

--- a/src/operationDefinitions/USCoreDocRef/docRefParamsToSearchParams.test.ts
+++ b/src/operationDefinitions/USCoreDocRef/docRefParamsToSearchParams.test.ts
@@ -1,0 +1,90 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+import { docRefParamsToSearchParams } from './docRefParamsToSearchParams';
+
+describe('docRefParamsToSearchParams', () => {
+    test('minimal params ', () => {
+        expect(docRefParamsToSearchParams({ patient: 'Patient/1' })).toMatchInlineSnapshot(`
+            Object {
+              "_count": "1",
+              "_sort": "-period",
+              "patient": "Patient/1",
+              "type": "http://loinc.org|34133-9",
+            }
+        `);
+    });
+    test('all params ', () => {
+        expect(
+            docRefParamsToSearchParams({
+                patient: 'Patient/1',
+                start: '1990-10-10',
+                end: '1995-10-10',
+                type: {
+                    system: 'https://fwoa.com',
+                    code: 'code123',
+                },
+                onDemand: false,
+            }),
+        ).toMatchInlineSnapshot(`
+            Object {
+              "patient": "Patient/1",
+              "period": Array [
+                "ge1990-10-10",
+                "le1995-10-10",
+              ],
+              "type": "https://fwoa.com|code123",
+            }
+        `);
+    });
+
+    test('on demand', () => {
+        expect(
+            docRefParamsToSearchParams({
+                patient: 'Patient/1',
+                onDemand: true,
+            }),
+        ).toMatchInlineSnapshot(`
+            Object {
+              "_count": "0",
+            }
+        `);
+    });
+
+    test('only start', () => {
+        expect(
+            docRefParamsToSearchParams({
+                patient: 'Patient/1',
+                start: '1990',
+            }),
+        ).toMatchInlineSnapshot(`
+            Object {
+              "patient": "Patient/1",
+              "period": Array [
+                "ge1990",
+              ],
+              "type": "http://loinc.org|34133-9",
+            }
+        `);
+    });
+
+    test('only end', () => {
+        expect(
+            docRefParamsToSearchParams({
+                patient: 'Patient/1',
+                end: '2000',
+            }),
+        ).toMatchInlineSnapshot(`
+            Object {
+              "patient": "Patient/1",
+              "period": Array [
+                "le2000",
+              ],
+              "type": "http://loinc.org|34133-9",
+            }
+        `);
+    });
+});

--- a/src/operationDefinitions/USCoreDocRef/docRefParamsToSearchParams.ts
+++ b/src/operationDefinitions/USCoreDocRef/docRefParamsToSearchParams.ts
@@ -1,0 +1,45 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+import { DocRefParams } from './parseParams';
+
+export const docRefParamsToSearchParams = (docRefParams: DocRefParams) => {
+    const { patient, start, end, type, onDemand } = docRefParams;
+
+    if (onDemand) {
+        // This implementation is not capable of generating documents on the fly. Just return an empty Bundle.
+        return { _count: '0' };
+    }
+
+    let searchParams: Record<string, string | string[]> = {
+        patient,
+    };
+
+    if (!start && !end) {
+        // only latest document
+        searchParams = { _sort: '-period', _count: '1', ...searchParams };
+    } else {
+        const dateParams = [];
+        if (start) {
+            dateParams.push(`ge${start}`);
+        }
+        if (end) {
+            dateParams.push(`le${end}`);
+        }
+        searchParams = { period: dateParams, ...searchParams };
+    }
+
+    let tokenParam;
+    if (type) {
+        tokenParam = type.system ? `${type.system}|${type.code}` : type.code;
+    } else {
+        // The LOINC code for a C-CDA Clinical Summary of Care (CCD) is 34133-9 (Summary of episode note)
+        tokenParam = 'http://loinc.org|34133-9';
+    }
+    searchParams = { type: tokenParam, ...searchParams };
+
+    return searchParams;
+};

--- a/src/operationDefinitions/USCoreDocRef/index.ts
+++ b/src/operationDefinitions/USCoreDocRef/index.ts
@@ -10,12 +10,12 @@ import { OperationDefinitionImplementation } from '../types';
 import ResourceHandler from '../../router/handlers/resourceHandler';
 import RouteHelper from '../../router/routes/routeHelper';
 import { DocRefParams, parsePostParams, parseQueryParams } from './parseParams';
-import { docRefParamsToSearchParams } from './docRefParamsToSearchParams';
+import { convertDocRefParamsToSearchParams } from './convertDocRefParamsToSearchParams';
 
 const searchTypeOperation: TypeOperation = 'search-type';
 
 const docRefImpl = async (resourceHandler: ResourceHandler, userIdentity: KeyValueMap, params: DocRefParams) => {
-    const searchParams = docRefParamsToSearchParams(params);
+    const searchParams = convertDocRefParamsToSearchParams(params);
     return resourceHandler.typeSearch('DocumentReference', searchParams, userIdentity);
 };
 

--- a/src/operationDefinitions/USCoreDocRef/index.ts
+++ b/src/operationDefinitions/USCoreDocRef/index.ts
@@ -1,0 +1,63 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+import express, { Router } from 'express';
+import { KeyValueMap, TypeOperation } from 'fhir-works-on-aws-interface';
+import { OperationDefinitionImplementation } from '../types';
+import ResourceHandler from '../../router/handlers/resourceHandler';
+import RouteHelper from '../../router/routes/routeHelper';
+import { DocRefParams, parsePostParams, parseQueryParams } from './parseParams';
+import { docRefParamsToSearchParams } from './docRefParamsToSearchParams';
+
+const searchTypeOperation: TypeOperation = 'search-type';
+
+const docRefImpl = async (resourceHandler: ResourceHandler, userIdentity: KeyValueMap, params: DocRefParams) => {
+    const searchParams = docRefParamsToSearchParams(params);
+    return resourceHandler.typeSearch('DocumentReference', searchParams, userIdentity);
+};
+
+export class USCoreDocRef implements OperationDefinitionImplementation {
+    readonly canonicalUrl = 'http://hl7.org/fhir/us/core/OperationDefinition/docref';
+
+    readonly requestInformation = {
+        operation: searchTypeOperation,
+        resourceType: 'DocumentReference',
+    };
+
+    private readonly resourceHandler: ResourceHandler;
+
+    readonly router: Router;
+
+    constructor(resourceHandler: ResourceHandler) {
+        this.resourceHandler = resourceHandler;
+        const path = '/DocumentReference/\\$docref';
+        const router = express.Router();
+        router.get(
+            path,
+            RouteHelper.wrapAsync(async (req: express.Request, res: express.Response) => {
+                const response = await docRefImpl(
+                    this.resourceHandler,
+                    res.locals.userIdentity,
+                    parseQueryParams(req.query),
+                );
+                res.send(response);
+            }),
+        );
+
+        router.post(
+            path,
+            RouteHelper.wrapAsync(async (req: express.Request, res: express.Response) => {
+                const response = await docRefImpl(
+                    this.resourceHandler,
+                    res.locals.userIdentity,
+                    parsePostParams(req.body),
+                );
+                res.send(response);
+            }),
+        );
+        this.router = router;
+    }
+}

--- a/src/operationDefinitions/USCoreDocRef/parseParams.test.ts
+++ b/src/operationDefinitions/USCoreDocRef/parseParams.test.ts
@@ -1,0 +1,270 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+import { parsePostParams, parseQueryParams } from './parseParams';
+
+describe('parseQueryParams', () => {
+    describe('valid params', () => {
+        test('all params', () => {
+            expect(
+                parseQueryParams({
+                    patient: 'patient/111',
+                    start: '1990',
+                    end: '2000',
+                    'on-demand': 'true',
+                }),
+            ).toMatchInlineSnapshot(`
+                Object {
+                  "end": "2000",
+                  "onDemand": true,
+                  "patient": "patient/111",
+                  "start": "1990",
+                }
+            `);
+        });
+
+        test('some params', () => {
+            expect(
+                parseQueryParams({
+                    patient: 'patient/111',
+                    start: '1990',
+                }),
+            ).toMatchInlineSnapshot(`
+                Object {
+                  "patient": "patient/111",
+                  "start": "1990",
+                }
+            `);
+        });
+
+        test('patient only', () => {
+            expect(
+                parseQueryParams({
+                    patient: 'patient/111',
+                }),
+            ).toMatchInlineSnapshot(`
+                Object {
+                  "patient": "patient/111",
+                }
+            `);
+        });
+    });
+
+    describe('invalid params', () => {
+        test('unknown param', () => {
+            expect(() =>
+                parseQueryParams({ patient: 'Patient/111', someUnknownParam: 1 }),
+            ).toThrowErrorMatchingInlineSnapshot(`"params/someUnknownParam Invalid parameter: \\"someUnknownParam\\""`);
+        });
+
+        test('missing patient', () => {
+            expect(() => parseQueryParams({ start: '1990' })).toThrowErrorMatchingInlineSnapshot(
+                `"params should have required property 'patient'"`,
+            );
+        });
+
+        test('bad types', () => {
+            expect(() => parseQueryParams({ patient: 23, start: ['1990', '1991'] })).toThrowErrorMatchingInlineSnapshot(
+                `"params/patient should be string, params/start should be string"`,
+            );
+        });
+
+        test('bad on-demand', () => {
+            expect(() =>
+                parseQueryParams({ patient: 'Patient/111', 'on-demand': 'notABoolean' }),
+            ).toThrowErrorMatchingInlineSnapshot(`"params/on-demand should be true or false"`);
+        });
+    });
+});
+
+describe('parsePostParams', () => {
+    describe('valid params', () => {
+        test('only patient', () => {
+            expect(
+                parsePostParams({
+                    resourceType: 'Parameters',
+                    parameter: [
+                        {
+                            name: 'patient',
+                            valueId: 'Patient/123',
+                        },
+                    ],
+                }),
+            ).toMatchInlineSnapshot(`
+                Object {
+                  "patient": "Patient/123",
+                }
+            `);
+        });
+
+        test('all params', () => {
+            expect(
+                parsePostParams({
+                    resourceType: 'Parameters',
+                    parameter: [
+                        {
+                            name: 'patient',
+                            valueId: 'Patient/123',
+                        },
+                        {
+                            name: 'codeableConcept',
+                            valueCodeableConcept: {
+                                coding: {
+                                    system: 'http://example.org',
+                                    code: 'code',
+                                    display: 'test',
+                                },
+                            },
+                        },
+                        {
+                            name: 'start',
+                            valueDate: '1990',
+                        },
+                        {
+                            name: 'end',
+                            valueDate: '2000',
+                        },
+                        {
+                            name: 'on-demand',
+                            valueBoolean: true,
+                        },
+                    ],
+                }),
+            ).toMatchInlineSnapshot(`
+                Object {
+                  "end": "2000",
+                  "onDemand": true,
+                  "patient": "Patient/123",
+                  "start": "1990",
+                  "type": Object {
+                    "code": "code",
+                    "system": "http://example.org",
+                  },
+                }
+            `);
+        });
+
+        test('some params', () => {
+            expect(
+                parsePostParams({
+                    resourceType: 'Parameters',
+                    parameter: [
+                        {
+                            name: 'patient',
+                            valueId: 'Patient/123',
+                        },
+                        {
+                            name: 'start',
+                            valueDate: '1990',
+                        },
+                        {
+                            name: 'end',
+                            valueDate: '2000',
+                        },
+                    ],
+                }),
+            ).toMatchInlineSnapshot(`
+                Object {
+                  "end": "2000",
+                  "patient": "Patient/123",
+                  "start": "1990",
+                }
+            `);
+        });
+    });
+
+    describe('invalid params', () => {
+        test('nonsense', () => {
+            expect(() =>
+                parsePostParams({
+                    someKey: 'someValue',
+                    someOtherKey: ['someOtherValue'],
+                }),
+            ).toThrowErrorMatchingInlineSnapshot(
+                `"params/someKey is not a valid property, params/someOtherKey is not a valid property, params should have required property 'resourceType', params should have required property 'parameter'"`,
+            );
+        });
+
+        test('no params', () => {
+            expect(() =>
+                parsePostParams({
+                    resourceType: 'Parameters',
+                    parameter: [],
+                }),
+            ).toThrowErrorMatchingInlineSnapshot(
+                `"params/parameter must be an array of parameters with names and types as specified on http://www.hl7.org/fhir/us/core/OperationDefinition-docref.html"`,
+            );
+        });
+
+        test('missing patient', () => {
+            expect(() =>
+                parsePostParams({
+                    resourceType: 'Parameters',
+                    parameter: [
+                        {
+                            name: 'start',
+                            valueDate: '1990',
+                        },
+                    ],
+                }),
+            ).toThrowErrorMatchingInlineSnapshot(`"patient parameter is required"`);
+        });
+
+        test('duplicate param name', () => {
+            expect(() =>
+                parsePostParams({
+                    resourceType: 'Parameters',
+                    parameter: [
+                        {
+                            name: 'patient',
+                            valueId: 'Patient/111',
+                        },
+                        {
+                            name: 'patient',
+                            valueId: 'Patient/222',
+                        },
+                    ],
+                }),
+            ).toThrowErrorMatchingInlineSnapshot(`"parameter names cannot repeat"`);
+        });
+
+        test('bad param name', () => {
+            expect(() =>
+                parsePostParams({
+                    resourceType: 'Parameters',
+                    parameter: [
+                        {
+                            name: 'patient',
+                            valueId: 'Patient/123',
+                        },
+                        {
+                            name: 'SomeBadName',
+                            valueDate: 'a',
+                        },
+                    ],
+                }),
+            ).toThrowErrorMatchingInlineSnapshot(
+                `"params/parameter must be an array of parameters with names and types as specified on http://www.hl7.org/fhir/us/core/OperationDefinition-docref.html"`,
+            );
+        });
+
+        test('type mismatch', () => {
+            expect(() =>
+                parsePostParams({
+                    resourceType: 'Parameters',
+                    parameter: [
+                        {
+                            name: 'patient',
+                            valueDate: '2000',
+                        },
+                    ],
+                }),
+            ).toThrowErrorMatchingInlineSnapshot(
+                `"params/parameter must be an array of parameters with names and types as specified on http://www.hl7.org/fhir/us/core/OperationDefinition-docref.html"`,
+            );
+        });
+    });
+});

--- a/src/operationDefinitions/USCoreDocRef/parseParams.ts
+++ b/src/operationDefinitions/USCoreDocRef/parseParams.ts
@@ -1,0 +1,239 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+import Ajv from 'ajv';
+import createError from 'http-errors';
+// @ts-ignore
+import ajvErrors from 'ajv-errors';
+
+const ajv = ajvErrors(new Ajv({ allErrors: true }));
+
+export interface DocRefParams {
+    patient: string;
+    start?: string;
+    end?: string;
+    type?: {
+        system?: string;
+        code: string;
+    };
+    onDemand?: boolean;
+}
+
+const queryParamsSchema = {
+    type: 'object',
+    properties: {
+        patient: { type: 'string' },
+        start: { type: 'string' },
+        end: { type: 'string' },
+        'on-demand': { enum: ['true', 'false'] },
+    },
+    required: ['patient'],
+    additionalProperties: {
+        not: true,
+        // eslint-disable-next-line no-template-curly-in-string
+        errorMessage: 'Invalid parameter: ${0#}',
+    },
+    errorMessage: {
+        properties: {
+            'on-demand': 'should be true or false',
+        },
+    },
+};
+
+const validateQueryParams = ajv.compile(queryParamsSchema);
+
+export const parseQueryParams = (queryParams: any): DocRefParams => {
+    if (queryParams.type) {
+        // This will likely be a common error, so we add a very specific mesage.
+        throw new createError.BadRequest('"type" parameter is not allowed on a GET request. Use POST instead');
+    }
+
+    if (validateQueryParams(queryParams)) {
+        const docRefParams: DocRefParams = {
+            patient: queryParams.patient,
+        };
+
+        if (queryParams.start) {
+            docRefParams.start = queryParams.start;
+        }
+
+        if (queryParams.end) {
+            docRefParams.end = queryParams.end;
+        }
+
+        if (queryParams['on-demand']) {
+            docRefParams.onDemand = queryParams['on-demand'] === 'true';
+        }
+
+        return docRefParams;
+    }
+
+    throw new createError.BadRequest(ajv.errorsText(validateQueryParams.errors, { dataVar: 'params' }));
+};
+
+const postParamsSchema = {
+    $schema: 'http://json-schema.org/draft-07/schema',
+    type: 'object',
+    required: ['resourceType', 'parameter'],
+    properties: {
+        resourceType: {
+            const: 'Parameters',
+            errorMessage: 'should equal "Parameters"',
+        },
+        id: {
+            type: 'string',
+        },
+        parameter: {
+            errorMessage:
+                'must be an array of parameters with names and types as specified on http://www.hl7.org/fhir/us/core/OperationDefinition-docref.html',
+            type: 'array',
+            minItems: 1,
+            maxItems: 5,
+            items: {
+                anyOf: [
+                    {
+                        type: 'object',
+                        required: ['name', 'valueCodeableConcept'],
+                        properties: {
+                            name: {
+                                const: 'codeableConcept',
+                            },
+                            valueCodeableConcept: {
+                                type: 'object',
+                                required: ['coding'],
+                                properties: {
+                                    coding: {
+                                        required: ['code'],
+                                        type: 'object',
+                                        properties: {
+                                            system: {
+                                                type: 'string',
+                                            },
+                                            code: {
+                                                type: 'string',
+                                            },
+                                            display: {
+                                                type: 'string',
+                                            },
+                                        },
+                                        additionalProperties: false,
+                                    },
+                                },
+                                additionalProperties: false,
+                            },
+                        },
+                        additionalProperties: false,
+                    },
+                    {
+                        type: 'object',
+                        required: ['name', 'valueId'],
+                        properties: {
+                            name: {
+                                const: 'patient',
+                            },
+                            valueId: {
+                                type: 'string',
+                            },
+                        },
+                        additionalProperties: false,
+                    },
+                    {
+                        type: 'object',
+                        required: ['name', 'valueDate'],
+                        properties: {
+                            name: {
+                                enum: ['start', 'end'],
+                            },
+                            valueDate: {
+                                type: 'string',
+                            },
+                        },
+                        additionalProperties: false,
+                    },
+                    {
+                        type: 'object',
+                        required: ['name', 'valueBoolean'],
+                        properties: {
+                            name: {
+                                const: 'on-demand',
+                            },
+                            valueBoolean: {
+                                type: 'boolean',
+                            },
+                        },
+                        additionalProperties: false,
+                    },
+                    {
+                        type: 'object',
+                        required: ['name', 'valueId'],
+                        properties: {
+                            name: {
+                                const: 'patient',
+                            },
+                            valueId: {
+                                type: 'string',
+                            },
+                        },
+                        additionalProperties: false,
+                    },
+                ],
+            },
+        },
+    },
+    additionalProperties: {
+        not: true,
+        errorMessage: 'is not a valid property',
+    },
+};
+
+const validatePostParams = ajv.compile(postParamsSchema);
+
+export const parsePostParams = (postParams: any): DocRefParams => {
+    if (validatePostParams(postParams)) {
+        const params: any[] = postParams.parameter;
+        const allowedNames = ['patient', 'start', 'end', 'on-demand', 'codeableConcept'];
+
+        const docRefParams: any = {};
+
+        allowedNames.forEach(name => {
+            const matches = params.filter(param => param.name === name);
+            if (matches.length > 1) {
+                throw new createError.BadRequest('parameter names cannot repeat');
+            }
+            if (name === 'patient' && matches.length === 0) {
+                throw new createError.BadRequest('patient parameter is required');
+            }
+            if (matches.length === 0) {
+                return;
+            }
+
+            switch (name) {
+                case 'patient':
+                    docRefParams[name] = matches[0].valueId;
+                    break;
+                case 'start':
+                case 'end':
+                    docRefParams[name] = matches[0].valueDate;
+                    break;
+                case 'on-demand':
+                    docRefParams.onDemand = matches[0].valueBoolean;
+                    break;
+                case 'codeableConcept':
+                    docRefParams.type = {
+                        system: matches[0].valueCodeableConcept.coding.system,
+                        code: matches[0].valueCodeableConcept.coding.code,
+                    };
+                    break;
+                default:
+                    // this should never happen
+                    throw new Error('Unable to parse params');
+            }
+        });
+
+        return docRefParams;
+    }
+    throw new createError.BadRequest(ajv.errorsText(validatePostParams.errors, { dataVar: 'params' }));
+};

--- a/src/operationDefinitions/types.ts
+++ b/src/operationDefinitions/types.ts
@@ -1,0 +1,31 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *  SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Router } from 'express';
+import { SystemOperation, TypeOperation } from 'fhir-works-on-aws-interface';
+
+export interface OperationDefinitionImplementation {
+    /**
+     * url of the corresponding OperationDefinition resource
+     */
+    canonicalUrl: string;
+
+    /**
+     * Request information used to resolve AuthZ. This is applicable to OperationDefinitions that can be mapped to
+     * the AuthZ rules of an existing SystemOperation/TypeOperation.
+     *
+     * For example, the $docref operation from US Core is effectively a 'search-type' operation on 'DocumentReference'.
+     */
+    requestInformation: {
+        operation: TypeOperation | SystemOperation;
+        resourceType?: string;
+        id?: string;
+        vid?: string;
+    };
+    /**
+     * express router that contains the implementation of the operation. It will be mounted on "/"
+     */
+    router: Router;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -877,6 +877,11 @@ acorn@^7.1.1:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.4.1.tgz#feaed255973d2e77555b83dbc08851a6c63520fa"
   integrity sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==
 
+ajv-errors@1.x:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/ajv-errors/-/ajv-errors-1.0.1.tgz#f35986aceb91afadec4102fbd85014950cefa64d"
+  integrity sha512-DCRfO/4nQ+89p/RK43i8Ezd41EqdGIU4ld7nGF8OQ14oc/we5rEntLCUa7+jrn3nn83BosfwZA0wb4pon2o8iQ==
+
 ajv@^6.10.0, ajv@^6.10.2, ajv@^6.11.0, ajv@^6.12.3:
   version "6.12.6"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.6.tgz#baf5a62e802b07d977034586f8c3baf5adf26df4"


### PR DESCRIPTION
Description of changes:
Basic implementation of docref: http://www.hl7.org/fhir/us/core/OperationDefinition-docref.html

The notable missing feature is generating documents on the fly. docref can either search for docs or generate docs on the fly(or both), but generating docs may require access to data from other EHR systems(we'd be generating a document that we don't have on fwoa) and it is out of scope.

**Note:** Right now the docref operation is unreachable code. I'll make additional PRs to "mount" docref when the US Core IG is being used. For now this PR will be merged on a feature branch.  

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.