### PR TITLE
feat: add docref to capability statement

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -57,7 +57,13 @@ export function generateServerlessRouter(
     }
 
     // Metadata
-    const metadataRoute: MetadataRoute = new MetadataRoute(fhirVersion, configHandler, registry, hasCORSEnabled);
+    const metadataRoute: MetadataRoute = new MetadataRoute(
+        fhirVersion,
+        configHandler,
+        registry,
+        operationRegistry,
+        hasCORSEnabled,
+    );
     app.use('/metadata', metadataRoute.router);
 
     if (fhirConfig.auth.strategy.service === 'SMART-on-FHIR') {

--- a/src/operationDefinitions/OperationDefinitionRegistry.test.ts
+++ b/src/operationDefinitions/OperationDefinitionRegistry.test.ts
@@ -13,6 +13,8 @@ import ResourceHandler from '../router/handlers/resourceHandler';
 const fakeRouter = (jest.fn() as unknown) as Router;
 const fakeOperation: OperationDefinitionImplementation = {
     canonicalUrl: 'https://fwoa.com/operation/fakeOperation',
+    name: 'fakeOperation',
+    documentation: 'The documentation for the fakeOperation',
     httpVerbs: ['GET'],
     path: '/Patient/fakeOperation',
     targetResourceType: 'Patient',
@@ -52,6 +54,31 @@ describe('OperationDefinitionRegistry', () => {
         expect(operationDefinitionRegistry.getOperation('GET', '/Patient/someOtherOperation')).toBeUndefined();
 
         expect(operationDefinitionRegistry.getOperation('GET', '/Patient/fakeOperation')).toBe(fakeOperation);
+    });
+
+    test('getCapabilities', () => {
+        const configHandlerMock = {
+            getResourceHandler: jest.fn().mockReturnValue({}),
+        };
+
+        const operationDefinitionRegistry = new OperationDefinitionRegistry(
+            (configHandlerMock as unknown) as ConfigHandler,
+            [fakeOperation],
+        );
+
+        expect(operationDefinitionRegistry.getCapabilities()).toMatchInlineSnapshot(`
+            Object {
+              "Patient": Object {
+                "operation": Array [
+                  Object {
+                    "definition": "https://fwoa.com/operation/fakeOperation",
+                    "documentation": "The documentation for the fakeOperation",
+                    "name": "fakeOperation",
+                  },
+                ],
+              },
+            }
+        `);
     });
 
     test('ResourceHandler not available', () => {

--- a/src/operationDefinitions/OperationDefinitionRegistry.ts
+++ b/src/operationDefinitions/OperationDefinitionRegistry.ts
@@ -8,6 +8,18 @@ import { Router } from 'express';
 import { OperationDefinitionImplementation } from './types';
 import ConfigHandler from '../configHandler';
 
+export interface OperationCapability {
+    operation: {
+        name: string;
+        definition: string;
+        documentation: string;
+    }[];
+}
+
+export interface OperationCapabilityStatement {
+    [resourceType: string]: OperationCapability;
+}
+
 export class OperationDefinitionRegistry {
     private readonly operations: OperationDefinitionImplementation[];
 
@@ -34,5 +46,24 @@ export class OperationDefinitionRegistry {
 
     getAllRouters(): Router[] {
         return this.routers;
+    }
+
+    getCapabilities(): OperationCapabilityStatement {
+        const capabilities: OperationCapabilityStatement = {};
+
+        this.operations.forEach(operation => {
+            if (!capabilities[operation.targetResourceType]) {
+                capabilities[operation.targetResourceType] = {
+                    operation: [],
+                };
+            }
+            capabilities[operation.targetResourceType].operation.push({
+                name: operation.name,
+                definition: operation.canonicalUrl,
+                documentation: operation.documentation,
+            });
+        });
+
+        return capabilities;
     }
 }

--- a/src/operationDefinitions/USCoreDocRef/index.ts
+++ b/src/operationDefinitions/USCoreDocRef/index.ts
@@ -21,6 +21,10 @@ const docRefImpl = async (resourceHandler: ResourceHandler, userIdentity: KeyVal
 
 export const USCoreDocRef: OperationDefinitionImplementation = {
     canonicalUrl: 'http://hl7.org/fhir/us/core/OperationDefinition/docref',
+    name: 'docref',
+    documentation:
+        "This operation is used to return all the references to documents related to a patient. \n\n The operation takes the optional input parameters: \n  - patient id\n  - start date\n  - end date\n  - document type \n\n and returns a [Bundle](http://hl7.org/fhir/bundle.html) of type \"searchset\" containing [US Core DocumentReference Profiles](http://hl7.org/fhir/us/core/StructureDefinition/us-core-documentreference) for the patient. If the server has or can create documents that are related to the patient, and that are available for the given user, the server returns the DocumentReference profiles needed to support the records.  The principle intended use for this operation is to provide a provider or patient with access to their available document information. \n\n This operation is *different* from a search by patient and type and date range because: \n\n 1. It is used to request a server *generate* a document based on the specified parameters. \n\n 1. If no parameters are specified, the server SHALL return a DocumentReference to the patient's most current CCD \n\n 1. If the server cannot *generate* a document based on the specified parameters, the operation will return an empty search bundle. \n\n This operation is the *same* as a FHIR RESTful search by patient,type and date range because: \n\n 1. References for *existing* documents that meet the requirements of the request SHOULD also be returned unless the client indicates they are only interested in 'on-demand' documents using the *on-demand* parameter." +
+        '\n\n This server does not generate documents on-demand',
     path: '/DocumentReference/$docref',
     httpVerbs: ['GET', 'POST'],
     targetResourceType: 'DocumentReference',

--- a/src/operationDefinitions/types.ts
+++ b/src/operationDefinitions/types.ts
@@ -14,6 +14,17 @@ export interface OperationDefinitionImplementation {
     readonly canonicalUrl: string;
 
     /**
+     * common name for the operation. It is found as `code` or `id` in the corresponding OperationDefinition resource
+     */
+    readonly name: string;
+
+    /**
+     * Usually based on the `description` of the corresponding OperationDefinition resource.
+     * documentation should also include details that are specific to this implementation of the operation
+     */
+    readonly documentation: string;
+
+    /**
      * url path used to invoke the operation
      * @example '/DocumentReference/$docref'
      */

--- a/src/router/metadata/cap.rest.resource.template.ts
+++ b/src/router/metadata/cap.rest.resource.template.ts
@@ -11,6 +11,10 @@ import {
     Resource,
 } from 'fhir-works-on-aws-interface';
 import { ResourceCapabilityStatement, ResourceCapability } from '../../registry/ResourceCapabilityInterface';
+import {
+    OperationCapability,
+    OperationCapabilityStatement,
+} from '../../operationDefinitions/OperationDefinitionRegistry';
 
 function makeResourceObject(
     resourceType: string,
@@ -19,6 +23,7 @@ function makeResourceObject(
     hasTypeSearch: boolean,
     searchCapabilities?: SearchCapabilities,
     resourceCapability?: ResourceCapability,
+    operationCapability?: OperationCapability,
 ) {
     const result: any = {
         type: resourceType,
@@ -40,6 +45,10 @@ function makeResourceObject(
         Object.assign(result, resourceCapability);
     }
 
+    if (operationCapability) {
+        Object.assign(result, operationCapability);
+    }
+
     return result;
 }
 
@@ -58,6 +67,7 @@ export function makeGenericResources(
     operations: TypeOperation[],
     searchCapabilityStatement: SearchCapabilityStatement,
     resourceCapabilityStatement: ResourceCapabilityStatement,
+    operationCapabilityStatement: OperationCapabilityStatement,
     updateCreate: boolean,
 ) {
     const resources: any[] = [];
@@ -74,6 +84,7 @@ export function makeGenericResources(
                 hasTypeSearch,
                 searchCapabilityStatement[resourceType],
                 resourceCapabilityStatement[resourceType],
+                operationCapabilityStatement[resourceType],
             ),
         );
     });

--- a/src/router/metadata/metadataHandler.test.ts
+++ b/src/router/metadata/metadataHandler.test.ts
@@ -440,12 +440,6 @@ test('R4: FHIR Config V4 without search', async () => {
     expect(response.resource.rest.length).toEqual(1);
     expect(response.resource.rest[0].resource.length).toEqual(SUPPORTED_R4_RESOURCES.length);
     expect(response.resource.rest[0].security.cors).toBeFalsy();
-    // see if the four CRUD + vRead operations are chosen
-    const expectedResourceSubset = {
-        interaction: makeOperation(['create', 'read', 'update', 'delete', 'vread', 'history-instance']),
-        updateCreate: configHandler.config.profile.genericResource!.persistence.updateCreateSupported,
-    };
-    expect(response.resource.rest[0].resource[0]).toMatchObject(expectedResourceSubset);
     expect(response.resource.rest[0].resource[0]).toMatchInlineSnapshot(`
         Object {
           "conditionalCreate": false,

--- a/src/router/metadata/metadataHandler.test.ts
+++ b/src/router/metadata/metadataHandler.test.ts
@@ -15,6 +15,7 @@ import JsonSchemaValidator from '../validation/jsonSchemaValidator';
 import ConfigHandler from '../../configHandler';
 import { utcTimeRegExp } from '../../regExpressions';
 import { FHIRStructureDefinitionRegistry } from '../../registry';
+import { OperationDefinitionRegistry } from '../../operationDefinitions/OperationDefinitionRegistry';
 
 const r4Validator = new JsonSchemaValidator('4.0.1');
 const stu3Validator = new JsonSchemaValidator('3.0.1');
@@ -331,6 +332,20 @@ const overrideStubs = {
 };
 const registry: FHIRStructureDefinitionRegistry = new FHIRStructureDefinitionRegistry();
 
+const operationRegistryMock: OperationDefinitionRegistry = ({
+    getCapabilities: jest.fn().mockReturnValue({
+        Account: {
+            operation: [
+                {
+                    definition: 'https://fwoa.com/operation/fakeOperation',
+                    documentation: 'The documentation for the fakeOperation',
+                    name: 'fakeOperation',
+                },
+            ],
+        },
+    }),
+} as unknown) as OperationDefinitionRegistry;
+
 describe('ERROR: test cases', () => {
     beforeEach(() => {
         // Ensures that for each test, we test the assertions in the catch block
@@ -342,7 +357,7 @@ describe('ERROR: test cases', () => {
             stu3FhirConfigWithExclusions(),
             SUPPORTED_STU3_RESOURCES,
         );
-        const metadataHandler: MetadataHandler = new MetadataHandler(configHandler, registry);
+        const metadataHandler: MetadataHandler = new MetadataHandler(configHandler, registry, operationRegistryMock);
         try {
             // OPERATE
             await metadataHandler.capabilities({ fhirVersion: '4.0.1', mode: 'full' });
@@ -360,7 +375,7 @@ describe('ERROR: test cases', () => {
             r4FhirConfigGeneric(overrideStubs),
             SUPPORTED_R4_RESOURCES,
         );
-        const metadataHandler: MetadataHandler = new MetadataHandler(configHandler, registry);
+        const metadataHandler: MetadataHandler = new MetadataHandler(configHandler, registry, operationRegistryMock);
         try {
             // OPERATE
             await metadataHandler.capabilities({ fhirVersion: '3.0.1', mode: 'full' });
@@ -377,7 +392,7 @@ test('STU3: FHIR Config V3 with 2 exclusions and search', async () => {
     const config = stu3FhirConfigWithExclusions(overrideStubs);
     const supportedGenericResources = ['AllergyIntolerance', 'Organization', 'Account', 'Patient'];
     const configHandler: ConfigHandler = new ConfigHandler(config, supportedGenericResources);
-    const metadataHandler: MetadataHandler = new MetadataHandler(configHandler, registry, true);
+    const metadataHandler: MetadataHandler = new MetadataHandler(configHandler, registry, operationRegistryMock, true);
     const response = await metadataHandler.capabilities({ fhirVersion: '3.0.1', mode: 'full' });
     const { genericResource } = config.profile;
     const excludedResources = genericResource ? genericResource.excludedSTU3Resources || [] : [];
@@ -417,7 +432,7 @@ test('STU3: FHIR Config V3 with 2 exclusions and search', async () => {
 });
 test('R4: FHIR Config V4 without search', async () => {
     const configHandler: ConfigHandler = new ConfigHandler(r4FhirConfigGeneric(overrideStubs), SUPPORTED_R4_RESOURCES);
-    const metadataHandler: MetadataHandler = new MetadataHandler(configHandler, registry);
+    const metadataHandler: MetadataHandler = new MetadataHandler(configHandler, registry, operationRegistryMock);
     const response = await metadataHandler.capabilities({ fhirVersion: '4.0.1', mode: 'full' });
     expect(response.resource).toBeDefined();
     expect(response.resource.acceptUnknown).toBeUndefined();
@@ -431,6 +446,45 @@ test('R4: FHIR Config V4 without search', async () => {
         updateCreate: configHandler.config.profile.genericResource!.persistence.updateCreateSupported,
     };
     expect(response.resource.rest[0].resource[0]).toMatchObject(expectedResourceSubset);
+    expect(response.resource.rest[0].resource[0]).toMatchInlineSnapshot(`
+        Object {
+          "conditionalCreate": false,
+          "conditionalDelete": "not-supported",
+          "conditionalRead": "not-supported",
+          "conditionalUpdate": false,
+          "interaction": Array [
+            Object {
+              "code": "create",
+            },
+            Object {
+              "code": "read",
+            },
+            Object {
+              "code": "update",
+            },
+            Object {
+              "code": "delete",
+            },
+            Object {
+              "code": "vread",
+            },
+            Object {
+              "code": "history-instance",
+            },
+          ],
+          "operation": Array [
+            Object {
+              "definition": "https://fwoa.com/operation/fakeOperation",
+              "documentation": "The documentation for the fakeOperation",
+              "name": "fakeOperation",
+            },
+          ],
+          "readHistory": false,
+          "type": "Account",
+          "updateCreate": false,
+          "versioning": "versioned",
+        }
+    `);
     expect(response.resource.rest[0].interaction).toEqual(
         makeOperation(r4FhirConfigGeneric(overrideStubs).profile.systemOperations),
     );
@@ -441,7 +495,7 @@ test('R4: FHIR Config V4 without search', async () => {
 test('R4: FHIR Config V4 with 3 exclusions and AllergyIntollerance special', async () => {
     const config = r4FhirConfigWithExclusions(overrideStubs);
     const configHandler: ConfigHandler = new ConfigHandler(config, SUPPORTED_R4_RESOURCES);
-    const metadataHandler: MetadataHandler = new MetadataHandler(configHandler, registry);
+    const metadataHandler: MetadataHandler = new MetadataHandler(configHandler, registry, operationRegistryMock);
     const response = await metadataHandler.capabilities({ fhirVersion: '4.0.1', mode: 'full' });
     const { genericResource } = config.profile;
     const excludedResources = genericResource ? genericResource.excludedR4Resources || [] : [];
@@ -483,7 +537,7 @@ test('R4: FHIR Config V4 with 3 exclusions and AllergyIntollerance special', asy
 test('R4: FHIR Config V4 no generic set-up & mix of STU3 & R4', async () => {
     const config = r4FhirConfigNoGeneric(overrideStubs);
     const configHandler: ConfigHandler = new ConfigHandler(config, SUPPORTED_R4_RESOURCES);
-    const metadataHandler: MetadataHandler = new MetadataHandler(configHandler, registry);
+    const metadataHandler: MetadataHandler = new MetadataHandler(configHandler, registry, operationRegistryMock);
     const configResource: any = config.profile.resources;
     const response = await metadataHandler.capabilities({ fhirVersion: '4.0.1', mode: 'full' });
     expect(response.resource).toBeDefined();
@@ -531,7 +585,7 @@ each([
     const fhirConfig = fhirConfigBuilder({ persistence, ...overrideStubs });
 
     const configHandler: ConfigHandler = new ConfigHandler(fhirConfig, SUPPORTED_R4_RESOURCES);
-    const metadataHandler: MetadataHandler = new MetadataHandler(configHandler, registry);
+    const metadataHandler: MetadataHandler = new MetadataHandler(configHandler, registry, operationRegistryMock);
     const response = await metadataHandler.capabilities({ fhirVersion: '4.0.1', mode: 'full' });
     response.resource.rest[0].resource.forEach((resource: any) => {
         const expectedResourceSubset = {
@@ -545,7 +599,7 @@ test('R4: FHIR Config V4 with bulkDataAccess', async () => {
     const r4ConfigWithBulkDataAccess = r4FhirConfigGeneric(overrideStubs);
     r4ConfigWithBulkDataAccess.profile.bulkDataAccess = stubs.bulkDataAccess;
     const configHandler: ConfigHandler = new ConfigHandler(r4ConfigWithBulkDataAccess, SUPPORTED_R4_RESOURCES);
-    const metadataHandler: MetadataHandler = new MetadataHandler(configHandler, registry);
+    const metadataHandler: MetadataHandler = new MetadataHandler(configHandler, registry, operationRegistryMock);
     const response = await metadataHandler.capabilities({ fhirVersion: '4.0.1', mode: 'full' });
 
     expect(response.resource.rest[0].operation).toEqual([
@@ -564,7 +618,7 @@ test('R4: FHIR Config V4 with bulkDataAccess', async () => {
 
 test('R4: FHIR Config V4 without bulkDataAccess', async () => {
     const configHandler: ConfigHandler = new ConfigHandler(r4FhirConfigGeneric(overrideStubs), SUPPORTED_R4_RESOURCES);
-    const metadataHandler: MetadataHandler = new MetadataHandler(configHandler, registry);
+    const metadataHandler: MetadataHandler = new MetadataHandler(configHandler, registry, operationRegistryMock);
     const response = await metadataHandler.capabilities({ fhirVersion: '4.0.1', mode: 'full' });
 
     expect(response.resource.rest[0].operation).toBeUndefined();
@@ -584,7 +638,7 @@ test('R4: FHIR Config V4 with all Oauth Policy endpoints', async () => {
         },
     };
     const configHandler: ConfigHandler = new ConfigHandler(r4ConfigWithOauthEndpoints, SUPPORTED_R4_RESOURCES);
-    const metadataHandler: MetadataHandler = new MetadataHandler(configHandler, registry);
+    const metadataHandler: MetadataHandler = new MetadataHandler(configHandler, registry, operationRegistryMock);
     const response = await metadataHandler.capabilities({ fhirVersion: '4.0.1', mode: 'full' });
 
     expect(response.resource.rest[0].security).toEqual({
@@ -645,7 +699,7 @@ test('R4: FHIR Config V4 with some Oauth Policy endpoints', async () => {
         },
     };
     const configHandler: ConfigHandler = new ConfigHandler(r4ConfigWithOauthEndpoints, SUPPORTED_R4_RESOURCES);
-    const metadataHandler: MetadataHandler = new MetadataHandler(configHandler, registry);
+    const metadataHandler: MetadataHandler = new MetadataHandler(configHandler, registry, operationRegistryMock);
     const response = await metadataHandler.capabilities({ fhirVersion: '4.0.1', mode: 'full' });
 
     expect(response.resource.rest[0].security).toEqual({
@@ -695,7 +749,7 @@ test('R4: FHIR Config V4 with all productInfo params', async () => {
         copyright: 'Copyright',
     };
     const configHandler: ConfigHandler = new ConfigHandler(r4ConfigWithAllProductInfo, SUPPORTED_R4_RESOURCES);
-    const metadataHandler: MetadataHandler = new MetadataHandler(configHandler, registry);
+    const metadataHandler: MetadataHandler = new MetadataHandler(configHandler, registry, operationRegistryMock);
     const response = await metadataHandler.capabilities({ fhirVersion: '4.0.1', mode: 'full' });
 
     const expectedResponse: any = {

--- a/src/router/metadata/metadataHandler.ts
+++ b/src/router/metadata/metadataHandler.ts
@@ -11,6 +11,7 @@ import makeRest from './cap.rest.template';
 import makeStatement from './cap.template';
 import ConfigHandler from '../../configHandler';
 import { FHIRStructureDefinitionRegistry } from '../../registry';
+import { OperationDefinitionRegistry } from '../../operationDefinitions/OperationDefinitionRegistry';
 
 export default class MetadataHandler implements Capabilities {
     configHandler: ConfigHandler;
@@ -19,10 +20,18 @@ export default class MetadataHandler implements Capabilities {
 
     readonly registry: FHIRStructureDefinitionRegistry;
 
-    constructor(handler: ConfigHandler, registry: FHIRStructureDefinitionRegistry, hasCORSEnabled: boolean = false) {
+    readonly operationRegistry: OperationDefinitionRegistry;
+
+    constructor(
+        handler: ConfigHandler,
+        registry: FHIRStructureDefinitionRegistry,
+        operationRegistry: OperationDefinitionRegistry,
+        hasCORSEnabled: boolean = false,
+    ) {
         this.configHandler = handler;
         this.hasCORSEnabled = hasCORSEnabled;
         this.registry = registry;
+        this.operationRegistry = operationRegistry;
     }
 
     private async generateResources(fhirVersion: FhirVersion) {
@@ -36,6 +45,7 @@ export default class MetadataHandler implements Capabilities {
                 this.configHandler.getGenericOperations(fhirVersion),
                 await this.configHandler.config.profile.genericResource.typeSearch.getCapabilities(),
                 await this.registry.getCapabilities(),
+                await this.operationRegistry.getCapabilities(),
                 updateCreate,
             );
         }

--- a/src/router/routes/metadataRoute.ts
+++ b/src/router/routes/metadataRoute.ts
@@ -8,6 +8,7 @@ import { CapabilityMode, FhirVersion } from 'fhir-works-on-aws-interface';
 import MetadataHandler from '../metadata/metadataHandler';
 import ConfigHandler from '../../configHandler';
 import { FHIRStructureDefinitionRegistry } from '../../registry';
+import { OperationDefinitionRegistry } from '../../operationDefinitions/OperationDefinitionRegistry';
 
 export default class MetadataRoute {
     readonly fhirVersion: FhirVersion;
@@ -20,10 +21,11 @@ export default class MetadataRoute {
         fhirVersion: FhirVersion,
         fhirConfigHandler: ConfigHandler,
         registry: FHIRStructureDefinitionRegistry,
+        operationRegistry: OperationDefinitionRegistry,
         hasCORSEnabled: boolean,
     ) {
         this.fhirVersion = fhirVersion;
-        this.metadataHandler = new MetadataHandler(fhirConfigHandler, registry, hasCORSEnabled);
+        this.metadataHandler = new MetadataHandler(fhirConfigHandler, registry, operationRegistry, hasCORSEnabled);
         this.router = express.Router();
         this.init();
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -877,7 +877,7 @@ acorn@^7.1.1:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.4.1.tgz#feaed255973d2e77555b83dbc08851a6c63520fa"
   integrity sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==
 
-ajv-errors@1.x:
+ajv-errors@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/ajv-errors/-/ajv-errors-1.0.1.tgz#f35986aceb91afadec4102fbd85014950cefa64d"
   integrity sha512-DCRfO/4nQ+89p/RK43i8Ezd41EqdGIU4ld7nGF8OQ14oc/we5rEntLCUa7+jrn3nn83BosfwZA0wb4pon2o8iQ==


### PR DESCRIPTION
Add the operations registered in `OperationDefinitionRegistry` to the capability statement

I chose to add a `documentation` field on the implementation of the operation instead of just copying the `documentation` from the `OperationDefinition` from the IG since docs for operations are sometimes vague and it is expected that servers document the particularities of their implementation. e.g. our `docref` documents that it does not generate documents on demand.

The fragment of the cap statement for docref looks like this:
```
{
  "type": "DocumentReference",
  ...
  "supportedProfile": [
    "http://hl7.org/fhir/us/core/StructureDefinition/us-core-documentreference"
  ],
  "operation": [
    {
      "name": "docref",
      "definition": "http://hl7.org/fhir/us/core/OperationDefinition/docref",
      "documentation": "This operation is used to return all the references to documents related to a patient..."
    }
  ]
}
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.