### PR TITLE
feat: add $docref operation

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@types/cors": "^2.8.7",
     "@types/express-serve-static-core": "^4.17.2",
     "ajv": "^6.11.0",
+    "ajv-errors": "^1.0.1",
     "aws-sdk": "^2.856.0",
     "aws-xray-sdk": "^3.2.0",
     "cors": "^2.8.5",

--- a/src/app.ts
+++ b/src/app.ts
@@ -22,6 +22,7 @@ import { applicationErrorMapper, httpErrorHandler, unknownErrorHandler } from '.
 import ExportRoute from './router/routes/exportRoute';
 import WellKnownUriRouteRoute from './router/routes/wellKnownUriRoute';
 import { FHIRStructureDefinitionRegistry } from './registry';
+import { initializeOperationRegistry } from './operationDefinitions';
 
 const configVersionSupported: ConfigVersion = 1;
 
@@ -38,6 +39,7 @@ export function generateServerlessRouter(
     const serverUrl: string = fhirConfig.server.url;
     let hasCORSEnabled: boolean = false;
     const registry = new FHIRStructureDefinitionRegistry(compiledImplementationGuides);
+    const operationRegistry = initializeOperationRegistry(configHandler);
 
     const app = express();
     app.use(express.urlencoded({ extended: true }));
@@ -70,7 +72,9 @@ export function generateServerlessRouter(
     // AuthZ
     app.use(async (req: express.Request, res: express.Response, next: express.NextFunction) => {
         try {
-            const requestInformation = getRequestInformation(req.method, req.path);
+            const requestInformation =
+                operationRegistry.getOperation(req.method, req.path)?.requestInformation ??
+                getRequestInformation(req.method, req.path);
             // Clean auth header (remove 'Bearer ')
             req.headers.authorization = cleanAuthHeader(req.headers.authorization);
             res.locals.userIdentity = await fhirConfig.auth.authorization.verifyAccessToken({
@@ -92,6 +96,11 @@ export function generateServerlessRouter(
         );
         app.use('/', exportRoute.router);
     }
+
+    // Operations defined by OperationDefinition resources
+    operationRegistry.getAllRouters().forEach(router => {
+        app.use('/', router);
+    });
 
     // Special Resources
     if (fhirConfig.profile.resources) {

--- a/src/app.ts
+++ b/src/app.ts
@@ -57,7 +57,13 @@ export function generateServerlessRouter(
     }
 
     // Metadata
-    const metadataRoute: MetadataRoute = new MetadataRoute(fhirVersion, configHandler, registry, hasCORSEnabled);
+    const metadataRoute: MetadataRoute = new MetadataRoute(
+        fhirVersion,
+        configHandler,
+        registry,
+        operationRegistry,
+        hasCORSEnabled,
+    );
     app.use('/metadata', metadataRoute.router);
 
     if (fhirConfig.auth.strategy.service === 'SMART-on-FHIR') {

--- a/src/implementationGuides/index.test.ts
+++ b/src/implementationGuides/index.test.ts
@@ -3,12 +3,12 @@
  *  SPDX-License-Identifier: Apache-2.0
  */
 
-import { StructureDefinitionImplementationGuides } from './index';
+import { RoutingImplementationGuides } from './index';
 
-describe('StructureDefinitionImplementationGuides', () => {
+describe('RoutingImplementationGuides', () => {
     describe(`compile`, async () => {
-        test(`valid StructureDefinition`, async () => {
-            const compiled = new StructureDefinitionImplementationGuides().compile([
+        test(`valid input`, async () => {
+            const compiled = new RoutingImplementationGuides().compile([
                 {
                     resourceType: 'StructureDefinition',
                     id: 'CARIN-BB-Organization',
@@ -28,24 +28,49 @@ describe('StructureDefinitionImplementationGuides', () => {
                     baseDefinition: 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-organization',
                     derivation: 'constraint',
                 },
+                {
+                    resourceType: 'OperationDefinition',
+                    id: 'docref',
+                    url: 'http://hl7.org/fhir/us/core/OperationDefinition/docref',
+                    version: '3.1.1',
+                    name: 'USCoreFetchDocumentReferences',
+                    title: 'US Core Fetch DocumentReferences',
+                    status: 'active',
+                    kind: 'operation',
+                    date: '2019-05-21',
+                    publisher: 'US Core Project',
+                    description:
+                        'This operation is used to return all the references to documents related to a patient...',
+                    code: 'docref',
+                    system: false,
+                    type: true,
+                    instance: false,
+                    parameter: [],
+                },
             ]);
 
             await expect(compiled).resolves.toMatchInlineSnapshot(`
-                Array [
-                  Object {
-                    "baseDefinition": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-organization",
-                    "description": "This profile builds on the USCoreOrganization Profile. It includes additional constraints relevant for the use cases addressed by this IG.",
-                    "name": "CARINBBOrganization",
-                    "resourceType": "StructureDefinition",
-                    "type": "Organization",
-                    "url": "http://hl7.org/fhir/us/carin/StructureDefinition/carin-bb-organization",
-                  },
-                ]
-            `);
+                        Array [
+                          Object {
+                            "baseDefinition": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-organization",
+                            "description": "This profile builds on the USCoreOrganization Profile. It includes additional constraints relevant for the use cases addressed by this IG.",
+                            "name": "CARINBBOrganization",
+                            "resourceType": "StructureDefinition",
+                            "type": "Organization",
+                            "url": "http://hl7.org/fhir/us/carin/StructureDefinition/carin-bb-organization",
+                          },
+                          Object {
+                            "description": "This operation is used to return all the references to documents related to a patient...",
+                            "name": "USCoreFetchDocumentReferences",
+                            "resourceType": "OperationDefinition",
+                            "url": "http://hl7.org/fhir/us/core/OperationDefinition/docref",
+                          },
+                        ]
+                    `);
         });
 
-        test(`invalid StructureDefinition`, async () => {
-            const compiled = new StructureDefinitionImplementationGuides().compile([
+        test(`invalid input`, async () => {
+            const compiled = new RoutingImplementationGuides().compile([
                 {
                     foo: 'bar',
                 },

--- a/src/implementationGuides/index.ts
+++ b/src/implementationGuides/index.ts
@@ -19,9 +19,20 @@ export type FhirStructureDefinition = {
 };
 
 /**
+ * Based on the FHIR OperationDefinition. This type only includes the fields that are required for the compile process.
+ * See: https://www.hl7.org/fhir/operationdefinition.html
+ */
+export type FhirOperationDefinition = {
+    resourceType: 'OperationDefinition';
+    url: string;
+    name: string;
+    description: string;
+};
+
+/**
  * This class compiles StructuredDefinitions from IG packages
  */
-export class StructureDefinitionImplementationGuides implements ImplementationGuides {
+export class RoutingImplementationGuides implements ImplementationGuides {
     /**
      * Compiles the contents of an Implementation Guide into an internal representation used to build the Capability Statement
      *
@@ -29,23 +40,43 @@ export class StructureDefinitionImplementationGuides implements ImplementationGu
      */
     // eslint-disable-next-line class-methods-use-this
     async compile(resources: any[]): Promise<any> {
-        const validStructureDefinitions: FhirStructureDefinition[] = [];
+        const validDefinitions: (FhirStructureDefinition | FhirOperationDefinition)[] = [];
         resources.forEach(s => {
-            if (StructureDefinitionImplementationGuides.isFhirStructureDefinition(s)) {
-                validStructureDefinitions.push(s);
+            if (
+                RoutingImplementationGuides.isFhirStructureDefinition(s) ||
+                RoutingImplementationGuides.isFhirOperationDefinition(s)
+            ) {
+                validDefinitions.push(s);
             } else {
-                throw new Error(`The following input is not a StructureDefinition: ${s.type} ${s.name}`);
+                throw new Error(
+                    `The following input is not a StructureDefinition nor a OperationDefinition: ${s.type} ${s.name}`,
+                );
             }
         });
 
-        return validStructureDefinitions.map((structureDefinition: any) => ({
-            name: structureDefinition.name,
-            url: structureDefinition.url,
-            type: structureDefinition.type,
-            resourceType: structureDefinition.resourceType,
-            description: structureDefinition.description,
-            baseDefinition: structureDefinition.baseDefinition,
-        }));
+        return validDefinitions.map(fhirDefinition => {
+            switch (fhirDefinition.resourceType) {
+                case 'StructureDefinition':
+                    return {
+                        name: fhirDefinition.name,
+                        url: fhirDefinition.url,
+                        type: fhirDefinition.type,
+                        resourceType: fhirDefinition.resourceType,
+                        description: fhirDefinition.description,
+                        baseDefinition: fhirDefinition.baseDefinition,
+                    };
+                case 'OperationDefinition':
+                    return {
+                        name: fhirDefinition.name,
+                        url: fhirDefinition.url,
+                        resourceType: fhirDefinition.resourceType,
+                        description: fhirDefinition.description,
+                    };
+                default:
+                    // this should never happen
+                    throw new Error('Unexpected error');
+            }
+        });
     }
 
     private static isFhirStructureDefinition(x: any): x is FhirStructureDefinition {
@@ -58,6 +89,17 @@ export class StructureDefinitionImplementationGuides implements ImplementationGu
             typeof x.description === 'string' &&
             typeof x.baseDefinition === 'string' &&
             typeof x.type === 'string'
+        );
+    }
+
+    private static isFhirOperationDefinition(x: any): x is FhirOperationDefinition {
+        return (
+            typeof x === 'object' &&
+            x &&
+            x.resourceType === 'OperationDefinition' &&
+            typeof x.url === 'string' &&
+            typeof x.name === 'string' &&
+            typeof x.description === 'string'
         );
     }
 }

--- a/src/operationDefinitions/OperationDefinitionRegistry.test.ts
+++ b/src/operationDefinitions/OperationDefinitionRegistry.test.ts
@@ -1,0 +1,68 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+import { Router } from 'express';
+import ConfigHandler from '../configHandler';
+import { OperationDefinitionRegistry } from './OperationDefinitionRegistry';
+import { OperationDefinitionImplementation } from './types';
+import ResourceHandler from '../router/handlers/resourceHandler';
+
+const fakeRouter = (jest.fn() as unknown) as Router;
+const fakeOperation: OperationDefinitionImplementation = {
+    canonicalUrl: 'https://fwoa.com/operation/fakeOperation',
+    httpVerbs: ['GET'],
+    path: '/Patient/fakeOperation',
+    targetResourceType: 'Patient',
+    requestInformation: {
+        operation: 'read',
+        resourceType: 'Patient',
+    },
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    buildRouter: (resourceHandler: ResourceHandler) => fakeRouter,
+};
+describe('OperationDefinitionRegistry', () => {
+    test('getAllRouters', () => {
+        const configHandlerMock = {
+            getResourceHandler: jest.fn().mockReturnValue({}),
+        };
+
+        const operationDefinitionRegistry = new OperationDefinitionRegistry(
+            (configHandlerMock as unknown) as ConfigHandler,
+            [fakeOperation],
+        );
+
+        expect(operationDefinitionRegistry.getAllRouters()).toHaveLength(1);
+        expect(operationDefinitionRegistry.getAllRouters()[0]).toBe(fakeRouter);
+    });
+
+    test('getOperation', () => {
+        const configHandlerMock = {
+            getResourceHandler: jest.fn().mockReturnValue({}),
+        };
+
+        const operationDefinitionRegistry = new OperationDefinitionRegistry(
+            (configHandlerMock as unknown) as ConfigHandler,
+            [fakeOperation],
+        );
+
+        expect(operationDefinitionRegistry.getOperation('PATCH', '/Patient/fakeOperation')).toBeUndefined();
+        expect(operationDefinitionRegistry.getOperation('GET', '/Patient/someOtherOperation')).toBeUndefined();
+
+        expect(operationDefinitionRegistry.getOperation('GET', '/Patient/fakeOperation')).toBe(fakeOperation);
+    });
+
+    test('ResourceHandler not available', () => {
+        const configHandlerMock = {
+            getResourceHandler: jest.fn().mockReturnValue(undefined),
+        };
+
+        expect(
+            () => new OperationDefinitionRegistry((configHandlerMock as unknown) as ConfigHandler, [fakeOperation]),
+        ).toThrowErrorMatchingInlineSnapshot(
+            `"Failed to initialize operation https://fwoa.com/operation/fakeOperation. Is your FhirConfig correct?"`,
+        );
+    });
+});

--- a/src/operationDefinitions/OperationDefinitionRegistry.test.ts
+++ b/src/operationDefinitions/OperationDefinitionRegistry.test.ts
@@ -13,6 +13,8 @@ import ResourceHandler from '../router/handlers/resourceHandler';
 const fakeRouter = (jest.fn() as unknown) as Router;
 const fakeOperation: OperationDefinitionImplementation = {
     canonicalUrl: 'https://fwoa.com/operation/fakeOperation',
+    name: 'fakeOperation',
+    documentation: 'The documentation for the fakeOperation',
     httpVerbs: ['GET'],
     path: '/Patient/fakeOperation',
     targetResourceType: 'Patient',
@@ -52,6 +54,31 @@ describe('OperationDefinitionRegistry', () => {
         expect(operationDefinitionRegistry.getOperation('GET', '/Patient/someOtherOperation')).toBeUndefined();
 
         expect(operationDefinitionRegistry.getOperation('GET', '/Patient/fakeOperation')).toBe(fakeOperation);
+    });
+
+    test('getCapabilities', () => {
+        const configHandlerMock = {
+            getResourceHandler: jest.fn().mockReturnValue({}),
+        };
+
+        const operationDefinitionRegistry = new OperationDefinitionRegistry(
+            (configHandlerMock as unknown) as ConfigHandler,
+            [fakeOperation],
+        );
+
+        expect(operationDefinitionRegistry.getCapabilities()).toMatchInlineSnapshot(`
+            Object {
+              "Patient": Object {
+                "operation": Array [
+                  Object {
+                    "definition": "https://fwoa.com/operation/fakeOperation",
+                    "documentation": "The documentation for the fakeOperation",
+                    "name": "fakeOperation",
+                  },
+                ],
+              },
+            }
+        `);
     });
 
     test('ResourceHandler not available', () => {

--- a/src/operationDefinitions/OperationDefinitionRegistry.ts
+++ b/src/operationDefinitions/OperationDefinitionRegistry.ts
@@ -1,0 +1,38 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+import { Router } from 'express';
+import { OperationDefinitionImplementation } from './types';
+import ConfigHandler from '../configHandler';
+
+export class OperationDefinitionRegistry {
+    private readonly operations: OperationDefinitionImplementation[];
+
+    private readonly routers: Router[];
+
+    constructor(configHandler: ConfigHandler, operations: OperationDefinitionImplementation[]) {
+        this.operations = operations;
+
+        this.routers = operations.map(operation => {
+            const resourceHandler = configHandler.getResourceHandler(operation.targetResourceType);
+            if (!resourceHandler) {
+                throw new Error(
+                    `Failed to initialize operation ${operation.canonicalUrl}. Is your FhirConfig correct?`,
+                );
+            }
+            console.log(`Enabling operation ${operation.canonicalUrl} at ${operation.path}`);
+            return operation.buildRouter(resourceHandler);
+        });
+    }
+
+    getOperation(method: string, path: string): OperationDefinitionImplementation | undefined {
+        return this.operations.find(o => o.path === path && o.httpVerbs.includes(method));
+    }
+
+    getAllRouters(): Router[] {
+        return this.routers;
+    }
+}

--- a/src/operationDefinitions/OperationDefinitionRegistry.ts
+++ b/src/operationDefinitions/OperationDefinitionRegistry.ts
@@ -8,6 +8,18 @@ import { Router } from 'express';
 import { OperationDefinitionImplementation } from './types';
 import ConfigHandler from '../configHandler';
 
+export interface OperationCapability {
+    operation: {
+        name: string;
+        definition: string;
+        documentation: string;
+    }[];
+}
+
+export interface OperationCapabilityStatement {
+    [resourceType: string]: OperationCapability;
+}
+
 export class OperationDefinitionRegistry {
     private readonly operations: OperationDefinitionImplementation[];
 
@@ -34,5 +46,24 @@ export class OperationDefinitionRegistry {
 
     getAllRouters(): Router[] {
         return this.routers;
+    }
+
+    getCapabilities(): OperationCapabilityStatement {
+        const capabilities: OperationCapabilityStatement = {};
+
+        this.operations.forEach(operation => {
+            if (!capabilities[operation.targetResourceType]) {
+                capabilities[operation.targetResourceType] = {
+                    operation: [],
+                };
+            }
+            capabilities[operation.targetResourceType].operation.push({
+                name: operation.name,
+                definition: operation.canonicalUrl,
+                documentation: operation.documentation,
+            });
+        });
+
+        return capabilities;
     }
 }

--- a/src/operationDefinitions/USCoreDocRef/convertDocRefParamsToSearchParams.ts
+++ b/src/operationDefinitions/USCoreDocRef/convertDocRefParamsToSearchParams.ts
@@ -1,0 +1,45 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+import { DocRefParams } from './parseParams';
+
+export const convertDocRefParamsToSearchParams = (docRefParams: DocRefParams) => {
+    const { patient, start, end, type, onDemand } = docRefParams;
+
+    if (onDemand) {
+        // This implementation is not capable of generating documents on the fly. Just return an empty Bundle.
+        return { _count: '0' };
+    }
+
+    let searchParams: Record<string, string | string[]> = {
+        patient,
+    };
+
+    if (!start && !end) {
+        // only latest document
+        searchParams = { _sort: '-period', _count: '1', ...searchParams };
+    } else {
+        const dateParams = [];
+        if (start) {
+            dateParams.push(`ge${start}`);
+        }
+        if (end) {
+            dateParams.push(`le${end}`);
+        }
+        searchParams = { period: dateParams, ...searchParams };
+    }
+
+    let tokenParam;
+    if (type) {
+        tokenParam = type.system ? `${type.system}|${type.code}` : type.code;
+    } else {
+        // The LOINC code for a C-CDA Clinical Summary of Care (CCD) is 34133-9 (Summary of episode note)
+        tokenParam = 'http://loinc.org|34133-9';
+    }
+    searchParams = { type: tokenParam, ...searchParams };
+
+    return searchParams;
+};

--- a/src/operationDefinitions/USCoreDocRef/docRefParamsToSearchParams.test.ts
+++ b/src/operationDefinitions/USCoreDocRef/docRefParamsToSearchParams.test.ts
@@ -1,0 +1,90 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+import { convertDocRefParamsToSearchParams } from './convertDocRefParamsToSearchParams';
+
+describe('docRefParamsToSearchParams', () => {
+    test('minimal params ', () => {
+        expect(convertDocRefParamsToSearchParams({ patient: 'Patient/1' })).toMatchInlineSnapshot(`
+            Object {
+              "_count": "1",
+              "_sort": "-period",
+              "patient": "Patient/1",
+              "type": "http://loinc.org|34133-9",
+            }
+        `);
+    });
+    test('all params ', () => {
+        expect(
+            convertDocRefParamsToSearchParams({
+                patient: 'Patient/1',
+                start: '1990-10-10',
+                end: '1995-10-10',
+                type: {
+                    system: 'https://fwoa.com',
+                    code: 'code123',
+                },
+                onDemand: false,
+            }),
+        ).toMatchInlineSnapshot(`
+            Object {
+              "patient": "Patient/1",
+              "period": Array [
+                "ge1990-10-10",
+                "le1995-10-10",
+              ],
+              "type": "https://fwoa.com|code123",
+            }
+        `);
+    });
+
+    test('on demand', () => {
+        expect(
+            convertDocRefParamsToSearchParams({
+                patient: 'Patient/1',
+                onDemand: true,
+            }),
+        ).toMatchInlineSnapshot(`
+            Object {
+              "_count": "0",
+            }
+        `);
+    });
+
+    test('only start', () => {
+        expect(
+            convertDocRefParamsToSearchParams({
+                patient: 'Patient/1',
+                start: '1990',
+            }),
+        ).toMatchInlineSnapshot(`
+            Object {
+              "patient": "Patient/1",
+              "period": Array [
+                "ge1990",
+              ],
+              "type": "http://loinc.org|34133-9",
+            }
+        `);
+    });
+
+    test('only end', () => {
+        expect(
+            convertDocRefParamsToSearchParams({
+                patient: 'Patient/1',
+                end: '2000',
+            }),
+        ).toMatchInlineSnapshot(`
+            Object {
+              "patient": "Patient/1",
+              "period": Array [
+                "le2000",
+              ],
+              "type": "http://loinc.org|34133-9",
+            }
+        `);
+    });
+});

--- a/src/operationDefinitions/USCoreDocRef/index.ts
+++ b/src/operationDefinitions/USCoreDocRef/index.ts
@@ -21,6 +21,10 @@ const docRefImpl = async (resourceHandler: ResourceHandler, userIdentity: KeyVal
 
 export const USCoreDocRef: OperationDefinitionImplementation = {
     canonicalUrl: 'http://hl7.org/fhir/us/core/OperationDefinition/docref',
+    name: 'docref',
+    documentation:
+        "This operation is used to return all the references to documents related to a patient. \n\n The operation takes the optional input parameters: \n  - patient id\n  - start date\n  - end date\n  - document type \n\n and returns a [Bundle](http://hl7.org/fhir/bundle.html) of type \"searchset\" containing [US Core DocumentReference Profiles](http://hl7.org/fhir/us/core/StructureDefinition/us-core-documentreference) for the patient. If the server has or can create documents that are related to the patient, and that are available for the given user, the server returns the DocumentReference profiles needed to support the records.  The principle intended use for this operation is to provide a provider or patient with access to their available document information. \n\n This operation is *different* from a search by patient and type and date range because: \n\n 1. It is used to request a server *generate* a document based on the specified parameters. \n\n 1. If no parameters are specified, the server SHALL return a DocumentReference to the patient's most current CCD \n\n 1. If the server cannot *generate* a document based on the specified parameters, the operation will return an empty search bundle. \n\n This operation is the *same* as a FHIR RESTful search by patient,type and date range because: \n\n 1. References for *existing* documents that meet the requirements of the request SHOULD also be returned unless the client indicates they are only interested in 'on-demand' documents using the *on-demand* parameter." +
+        '\n\n This server does not generate documents on-demand',
     path: '/DocumentReference/$docref',
     httpVerbs: ['GET', 'POST'],
     targetResourceType: 'DocumentReference',

--- a/src/operationDefinitions/USCoreDocRef/index.ts
+++ b/src/operationDefinitions/USCoreDocRef/index.ts
@@ -1,0 +1,63 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+import express, { Router } from 'express';
+import { KeyValueMap, TypeOperation } from 'fhir-works-on-aws-interface';
+import { OperationDefinitionImplementation } from '../types';
+import ResourceHandler from '../../router/handlers/resourceHandler';
+import RouteHelper from '../../router/routes/routeHelper';
+import { DocRefParams, parsePostParams, parseQueryParams } from './parseParams';
+import { convertDocRefParamsToSearchParams } from './convertDocRefParamsToSearchParams';
+
+const searchTypeOperation: TypeOperation = 'search-type';
+
+const docRefImpl = async (resourceHandler: ResourceHandler, userIdentity: KeyValueMap, params: DocRefParams) => {
+    const searchParams = convertDocRefParamsToSearchParams(params);
+    return resourceHandler.typeSearch('DocumentReference', searchParams, userIdentity);
+};
+
+export class USCoreDocRef implements OperationDefinitionImplementation {
+    readonly canonicalUrl = 'http://hl7.org/fhir/us/core/OperationDefinition/docref';
+
+    readonly requestInformation = {
+        operation: searchTypeOperation,
+        resourceType: 'DocumentReference',
+    };
+
+    private readonly resourceHandler: ResourceHandler;
+
+    readonly router: Router;
+
+    constructor(resourceHandler: ResourceHandler) {
+        this.resourceHandler = resourceHandler;
+        const path = '/DocumentReference/\\$docref';
+        const router = express.Router();
+        router.get(
+            path,
+            RouteHelper.wrapAsync(async (req: express.Request, res: express.Response) => {
+                const response = await docRefImpl(
+                    this.resourceHandler,
+                    res.locals.userIdentity,
+                    parseQueryParams(req.query),
+                );
+                res.send(response);
+            }),
+        );
+
+        router.post(
+            path,
+            RouteHelper.wrapAsync(async (req: express.Request, res: express.Response) => {
+                const response = await docRefImpl(
+                    this.resourceHandler,
+                    res.locals.userIdentity,
+                    parsePostParams(req.body),
+                );
+                res.send(response);
+            }),
+        );
+        this.router = router;
+    }
+}

--- a/src/operationDefinitions/USCoreDocRef/index.ts
+++ b/src/operationDefinitions/USCoreDocRef/index.ts
@@ -4,7 +4,7 @@
  *
  */
 
-import express, { Router } from 'express';
+import express from 'express';
 import { KeyValueMap, TypeOperation } from 'fhir-works-on-aws-interface';
 import { OperationDefinitionImplementation } from '../types';
 import ResourceHandler from '../../router/handlers/resourceHandler';
@@ -19,27 +19,23 @@ const docRefImpl = async (resourceHandler: ResourceHandler, userIdentity: KeyVal
     return resourceHandler.typeSearch('DocumentReference', searchParams, userIdentity);
 };
 
-export class USCoreDocRef implements OperationDefinitionImplementation {
-    readonly canonicalUrl = 'http://hl7.org/fhir/us/core/OperationDefinition/docref';
-
-    readonly requestInformation = {
+export const USCoreDocRef: OperationDefinitionImplementation = {
+    canonicalUrl: 'http://hl7.org/fhir/us/core/OperationDefinition/docref',
+    path: '/DocumentReference/$docref',
+    httpVerbs: ['GET', 'POST'],
+    targetResourceType: 'DocumentReference',
+    requestInformation: {
         operation: searchTypeOperation,
         resourceType: 'DocumentReference',
-    };
-
-    private readonly resourceHandler: ResourceHandler;
-
-    readonly router: Router;
-
-    constructor(resourceHandler: ResourceHandler) {
-        this.resourceHandler = resourceHandler;
+    },
+    buildRouter: (resourceHandler: ResourceHandler) => {
         const path = '/DocumentReference/\\$docref';
         const router = express.Router();
         router.get(
             path,
             RouteHelper.wrapAsync(async (req: express.Request, res: express.Response) => {
                 const response = await docRefImpl(
-                    this.resourceHandler,
+                    resourceHandler,
                     res.locals.userIdentity,
                     parseQueryParams(req.query),
                 );
@@ -50,14 +46,11 @@ export class USCoreDocRef implements OperationDefinitionImplementation {
         router.post(
             path,
             RouteHelper.wrapAsync(async (req: express.Request, res: express.Response) => {
-                const response = await docRefImpl(
-                    this.resourceHandler,
-                    res.locals.userIdentity,
-                    parsePostParams(req.body),
-                );
+                const response = await docRefImpl(resourceHandler, res.locals.userIdentity, parsePostParams(req.body));
                 res.send(response);
             }),
         );
-        this.router = router;
-    }
-}
+
+        return router;
+    },
+};

--- a/src/operationDefinitions/USCoreDocRef/index.ts
+++ b/src/operationDefinitions/USCoreDocRef/index.ts
@@ -5,7 +5,7 @@
  */
 
 import express from 'express';
-import { KeyValueMap, TypeOperation } from 'fhir-works-on-aws-interface';
+import { KeyValueMap, RequestContext, TypeOperation } from 'fhir-works-on-aws-interface';
 import { OperationDefinitionImplementation } from '../types';
 import ResourceHandler from '../../router/handlers/resourceHandler';
 import RouteHelper from '../../router/routes/routeHelper';
@@ -14,9 +14,14 @@ import { convertDocRefParamsToSearchParams } from './convertDocRefParamsToSearch
 
 const searchTypeOperation: TypeOperation = 'search-type';
 
-const docRefImpl = async (resourceHandler: ResourceHandler, userIdentity: KeyValueMap, params: DocRefParams) => {
+const docRefImpl = async (
+    resourceHandler: ResourceHandler,
+    userIdentity: KeyValueMap,
+    params: DocRefParams,
+    requestContext: RequestContext,
+) => {
     const searchParams = convertDocRefParamsToSearchParams(params);
-    return resourceHandler.typeSearch('DocumentReference', searchParams, userIdentity);
+    return resourceHandler.typeSearch('DocumentReference', searchParams, userIdentity, requestContext);
 };
 
 export const USCoreDocRef: OperationDefinitionImplementation = {
@@ -42,6 +47,7 @@ export const USCoreDocRef: OperationDefinitionImplementation = {
                     resourceHandler,
                     res.locals.userIdentity,
                     parseQueryParams(req.query),
+                    res.locals.requestContext,
                 );
                 res.send(response);
             }),
@@ -50,7 +56,12 @@ export const USCoreDocRef: OperationDefinitionImplementation = {
         router.post(
             path,
             RouteHelper.wrapAsync(async (req: express.Request, res: express.Response) => {
-                const response = await docRefImpl(resourceHandler, res.locals.userIdentity, parsePostParams(req.body));
+                const response = await docRefImpl(
+                    resourceHandler,
+                    res.locals.userIdentity,
+                    parsePostParams(req.body),
+                    res.locals.requestContext,
+                );
                 res.send(response);
             }),
         );

--- a/src/operationDefinitions/USCoreDocRef/parseParams.test.ts
+++ b/src/operationDefinitions/USCoreDocRef/parseParams.test.ts
@@ -1,0 +1,270 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+import { parsePostParams, parseQueryParams } from './parseParams';
+
+describe('parseQueryParams', () => {
+    describe('valid params', () => {
+        test('all params', () => {
+            expect(
+                parseQueryParams({
+                    patient: 'patient/111',
+                    start: '1990',
+                    end: '2000',
+                    'on-demand': 'true',
+                }),
+            ).toMatchInlineSnapshot(`
+                Object {
+                  "end": "2000",
+                  "onDemand": true,
+                  "patient": "patient/111",
+                  "start": "1990",
+                }
+            `);
+        });
+
+        test('some params', () => {
+            expect(
+                parseQueryParams({
+                    patient: 'patient/111',
+                    start: '1990',
+                }),
+            ).toMatchInlineSnapshot(`
+                Object {
+                  "patient": "patient/111",
+                  "start": "1990",
+                }
+            `);
+        });
+
+        test('patient only', () => {
+            expect(
+                parseQueryParams({
+                    patient: 'patient/111',
+                }),
+            ).toMatchInlineSnapshot(`
+                Object {
+                  "patient": "patient/111",
+                }
+            `);
+        });
+    });
+
+    describe('invalid params', () => {
+        test('unknown param', () => {
+            expect(() =>
+                parseQueryParams({ patient: 'Patient/111', someUnknownParam: 1 }),
+            ).toThrowErrorMatchingInlineSnapshot(`"params/someUnknownParam Invalid parameter: \\"someUnknownParam\\""`);
+        });
+
+        test('missing patient', () => {
+            expect(() => parseQueryParams({ start: '1990' })).toThrowErrorMatchingInlineSnapshot(
+                `"params should have required property 'patient'"`,
+            );
+        });
+
+        test('bad types', () => {
+            expect(() => parseQueryParams({ patient: 23, start: ['1990', '1991'] })).toThrowErrorMatchingInlineSnapshot(
+                `"params/patient should be string, params/start should be string"`,
+            );
+        });
+
+        test('bad on-demand', () => {
+            expect(() =>
+                parseQueryParams({ patient: 'Patient/111', 'on-demand': 'notABoolean' }),
+            ).toThrowErrorMatchingInlineSnapshot(`"params/on-demand should be true or false"`);
+        });
+    });
+});
+
+describe('parsePostParams', () => {
+    describe('valid params', () => {
+        test('only patient', () => {
+            expect(
+                parsePostParams({
+                    resourceType: 'Parameters',
+                    parameter: [
+                        {
+                            name: 'patient',
+                            valueId: 'Patient/123',
+                        },
+                    ],
+                }),
+            ).toMatchInlineSnapshot(`
+                Object {
+                  "patient": "Patient/123",
+                }
+            `);
+        });
+
+        test('all params', () => {
+            expect(
+                parsePostParams({
+                    resourceType: 'Parameters',
+                    parameter: [
+                        {
+                            name: 'patient',
+                            valueId: 'Patient/123',
+                        },
+                        {
+                            name: 'codeableConcept',
+                            valueCodeableConcept: {
+                                coding: {
+                                    system: 'http://example.org',
+                                    code: 'code',
+                                    display: 'test',
+                                },
+                            },
+                        },
+                        {
+                            name: 'start',
+                            valueDate: '1990',
+                        },
+                        {
+                            name: 'end',
+                            valueDate: '2000',
+                        },
+                        {
+                            name: 'on-demand',
+                            valueBoolean: true,
+                        },
+                    ],
+                }),
+            ).toMatchInlineSnapshot(`
+                Object {
+                  "end": "2000",
+                  "onDemand": true,
+                  "patient": "Patient/123",
+                  "start": "1990",
+                  "type": Object {
+                    "code": "code",
+                    "system": "http://example.org",
+                  },
+                }
+            `);
+        });
+
+        test('some params', () => {
+            expect(
+                parsePostParams({
+                    resourceType: 'Parameters',
+                    parameter: [
+                        {
+                            name: 'patient',
+                            valueId: 'Patient/123',
+                        },
+                        {
+                            name: 'start',
+                            valueDate: '1990',
+                        },
+                        {
+                            name: 'end',
+                            valueDate: '2000',
+                        },
+                    ],
+                }),
+            ).toMatchInlineSnapshot(`
+                Object {
+                  "end": "2000",
+                  "patient": "Patient/123",
+                  "start": "1990",
+                }
+            `);
+        });
+    });
+
+    describe('invalid params', () => {
+        test('nonsense', () => {
+            expect(() =>
+                parsePostParams({
+                    someKey: 'someValue',
+                    someOtherKey: ['someOtherValue'],
+                }),
+            ).toThrowErrorMatchingInlineSnapshot(
+                `"params/someKey is not a valid property, params/someOtherKey is not a valid property, params should have required property 'resourceType', params should have required property 'parameter'"`,
+            );
+        });
+
+        test('no params', () => {
+            expect(() =>
+                parsePostParams({
+                    resourceType: 'Parameters',
+                    parameter: [],
+                }),
+            ).toThrowErrorMatchingInlineSnapshot(
+                `"params/parameter must be an array of parameters with names and types as specified on http://www.hl7.org/fhir/us/core/OperationDefinition-docref.html"`,
+            );
+        });
+
+        test('missing patient', () => {
+            expect(() =>
+                parsePostParams({
+                    resourceType: 'Parameters',
+                    parameter: [
+                        {
+                            name: 'start',
+                            valueDate: '1990',
+                        },
+                    ],
+                }),
+            ).toThrowErrorMatchingInlineSnapshot(`"patient parameter is required"`);
+        });
+
+        test('duplicate param name', () => {
+            expect(() =>
+                parsePostParams({
+                    resourceType: 'Parameters',
+                    parameter: [
+                        {
+                            name: 'patient',
+                            valueId: 'Patient/111',
+                        },
+                        {
+                            name: 'patient',
+                            valueId: 'Patient/222',
+                        },
+                    ],
+                }),
+            ).toThrowErrorMatchingInlineSnapshot(`"parameter names cannot repeat"`);
+        });
+
+        test('bad param name', () => {
+            expect(() =>
+                parsePostParams({
+                    resourceType: 'Parameters',
+                    parameter: [
+                        {
+                            name: 'patient',
+                            valueId: 'Patient/123',
+                        },
+                        {
+                            name: 'SomeBadName',
+                            valueDate: 'a',
+                        },
+                    ],
+                }),
+            ).toThrowErrorMatchingInlineSnapshot(
+                `"params/parameter must be an array of parameters with names and types as specified on http://www.hl7.org/fhir/us/core/OperationDefinition-docref.html"`,
+            );
+        });
+
+        test('type mismatch', () => {
+            expect(() =>
+                parsePostParams({
+                    resourceType: 'Parameters',
+                    parameter: [
+                        {
+                            name: 'patient',
+                            valueDate: '2000',
+                        },
+                    ],
+                }),
+            ).toThrowErrorMatchingInlineSnapshot(
+                `"params/parameter must be an array of parameters with names and types as specified on http://www.hl7.org/fhir/us/core/OperationDefinition-docref.html"`,
+            );
+        });
+    });
+});

--- a/src/operationDefinitions/USCoreDocRef/parseParams.ts
+++ b/src/operationDefinitions/USCoreDocRef/parseParams.ts
@@ -1,0 +1,238 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+import Ajv from 'ajv';
+import createError from 'http-errors';
+// @ts-ignore
+import ajvErrors from 'ajv-errors';
+
+const ajv = ajvErrors(new Ajv({ allErrors: true }));
+
+export interface DocRefParams {
+    patient: string;
+    start?: string;
+    end?: string;
+    type?: {
+        system?: string;
+        code: string;
+    };
+    onDemand?: boolean;
+}
+
+const queryParamsSchema = {
+    type: 'object',
+    properties: {
+        patient: { type: 'string' },
+        start: { type: 'string' },
+        end: { type: 'string' },
+        'on-demand': { enum: ['true', 'false'] },
+    },
+    required: ['patient'],
+    additionalProperties: {
+        not: true,
+        // eslint-disable-next-line no-template-curly-in-string
+        errorMessage: 'Invalid parameter: ${0#}',
+    },
+    errorMessage: {
+        properties: {
+            'on-demand': 'should be true or false',
+        },
+    },
+};
+
+const validateQueryParams = ajv.compile(queryParamsSchema);
+
+export const parseQueryParams = (queryParams: any): DocRefParams => {
+    if (queryParams.type) {
+        // This will likely be a common error, so we add a very specific message.
+        throw new createError.BadRequest('"type" parameter is not allowed on a GET request. Use POST instead');
+    }
+
+    if (!validateQueryParams(queryParams)) {
+        throw new createError.BadRequest(ajv.errorsText(validateQueryParams.errors, { dataVar: 'params' }));
+    }
+    const docRefParams: DocRefParams = {
+        patient: queryParams.patient,
+    };
+
+    if (queryParams.start) {
+        docRefParams.start = queryParams.start;
+    }
+
+    if (queryParams.end) {
+        docRefParams.end = queryParams.end;
+    }
+
+    if (queryParams['on-demand']) {
+        docRefParams.onDemand = queryParams['on-demand'] === 'true';
+    }
+
+    return docRefParams;
+};
+
+const postParamsSchema = {
+    $schema: 'http://json-schema.org/draft-07/schema',
+    type: 'object',
+    required: ['resourceType', 'parameter'],
+    properties: {
+        resourceType: {
+            const: 'Parameters',
+            errorMessage: 'should equal "Parameters"',
+        },
+        id: {
+            type: 'string',
+        },
+        parameter: {
+            errorMessage:
+                'must be an array of parameters with names and types as specified on http://www.hl7.org/fhir/us/core/OperationDefinition-docref.html',
+            type: 'array',
+            minItems: 1,
+            maxItems: 5,
+            items: {
+                anyOf: [
+                    {
+                        type: 'object',
+                        required: ['name', 'valueCodeableConcept'],
+                        properties: {
+                            name: {
+                                const: 'codeableConcept',
+                            },
+                            valueCodeableConcept: {
+                                type: 'object',
+                                required: ['coding'],
+                                properties: {
+                                    coding: {
+                                        required: ['code'],
+                                        type: 'object',
+                                        properties: {
+                                            system: {
+                                                type: 'string',
+                                            },
+                                            code: {
+                                                type: 'string',
+                                            },
+                                            display: {
+                                                type: 'string',
+                                            },
+                                        },
+                                        additionalProperties: false,
+                                    },
+                                },
+                                additionalProperties: false,
+                            },
+                        },
+                        additionalProperties: false,
+                    },
+                    {
+                        type: 'object',
+                        required: ['name', 'valueId'],
+                        properties: {
+                            name: {
+                                const: 'patient',
+                            },
+                            valueId: {
+                                type: 'string',
+                            },
+                        },
+                        additionalProperties: false,
+                    },
+                    {
+                        type: 'object',
+                        required: ['name', 'valueDate'],
+                        properties: {
+                            name: {
+                                enum: ['start', 'end'],
+                            },
+                            valueDate: {
+                                type: 'string',
+                            },
+                        },
+                        additionalProperties: false,
+                    },
+                    {
+                        type: 'object',
+                        required: ['name', 'valueBoolean'],
+                        properties: {
+                            name: {
+                                const: 'on-demand',
+                            },
+                            valueBoolean: {
+                                type: 'boolean',
+                            },
+                        },
+                        additionalProperties: false,
+                    },
+                    {
+                        type: 'object',
+                        required: ['name', 'valueId'],
+                        properties: {
+                            name: {
+                                const: 'patient',
+                            },
+                            valueId: {
+                                type: 'string',
+                            },
+                        },
+                        additionalProperties: false,
+                    },
+                ],
+            },
+        },
+    },
+    additionalProperties: {
+        not: true,
+        errorMessage: 'is not a valid property',
+    },
+};
+
+const validatePostParams = ajv.compile(postParamsSchema);
+
+export const parsePostParams = (postParams: any): DocRefParams => {
+    if (!validatePostParams(postParams)) {
+        throw new createError.BadRequest(ajv.errorsText(validatePostParams.errors, { dataVar: 'params' }));
+    }
+    const params: any[] = postParams.parameter;
+    const allowedNames = ['patient', 'start', 'end', 'on-demand', 'codeableConcept'];
+
+    const docRefParams: any = {};
+
+    allowedNames.forEach(name => {
+        const matches = params.filter(param => param.name === name);
+        if (matches.length > 1) {
+            throw new createError.BadRequest('parameter names cannot repeat');
+        }
+        if (name === 'patient' && matches.length === 0) {
+            throw new createError.BadRequest('patient parameter is required');
+        }
+        if (matches.length === 0) {
+            return;
+        }
+
+        switch (name) {
+            case 'patient':
+                docRefParams[name] = matches[0].valueId;
+                break;
+            case 'start':
+            case 'end':
+                docRefParams[name] = matches[0].valueDate;
+                break;
+            case 'on-demand':
+                docRefParams.onDemand = matches[0].valueBoolean;
+                break;
+            case 'codeableConcept':
+                docRefParams.type = {
+                    system: matches[0].valueCodeableConcept.coding.system,
+                    code: matches[0].valueCodeableConcept.coding.code,
+                };
+                break;
+            default:
+                // this should never happen
+                throw new Error('Unable to parse params');
+        }
+    });
+
+    return docRefParams;
+};

--- a/src/operationDefinitions/USCoreDocRef/parseParams.ts
+++ b/src/operationDefinitions/USCoreDocRef/parseParams.ts
@@ -9,7 +9,7 @@ import createError from 'http-errors';
 // @ts-ignore
 import ajvErrors from 'ajv-errors';
 
-const ajv = ajvErrors(new Ajv({ allErrors: true }));
+const ajv = ajvErrors(new Ajv({ allErrors: true, jsonPointers: true }));
 
 export interface DocRefParams {
     patient: string;

--- a/src/operationDefinitions/index.ts
+++ b/src/operationDefinitions/index.ts
@@ -1,0 +1,29 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+import { OperationDefinitionImplementation } from './types';
+import { USCoreDocRef } from './USCoreDocRef';
+import { OperationDefinitionRegistry } from './OperationDefinitionRegistry';
+import ConfigHandler from '../configHandler';
+
+export const initializeOperationRegistry = (configHandler: ConfigHandler) => {
+    const { compiledImplementationGuides } = configHandler.config.profile;
+    const operations: OperationDefinitionImplementation[] = [];
+
+    // Add the operations to enable on this FHIR server.
+    // The recommended approach is to enable operations if the corresponding `OperationDefinition` is found on the `compiledImplementationGuides`,
+    // but this file can be updated to use a different enablement criteria or to disable operations altogether.
+    if (
+        compiledImplementationGuides &&
+        compiledImplementationGuides.find(
+            (x: any) => x.resourceType === 'OperationDefinition' && x.url === USCoreDocRef.canonicalUrl,
+        )
+    ) {
+        operations.push(USCoreDocRef);
+    }
+
+    return new OperationDefinitionRegistry(configHandler, operations);
+};

--- a/src/operationDefinitions/types.ts
+++ b/src/operationDefinitions/types.ts
@@ -1,0 +1,31 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *  SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Router } from 'express';
+import { SystemOperation, TypeOperation } from 'fhir-works-on-aws-interface';
+
+export interface OperationDefinitionImplementation {
+    /**
+     * url of the corresponding OperationDefinition resource
+     */
+    canonicalUrl: string;
+
+    /**
+     * Request information used to resolve AuthZ. This is applicable to OperationDefinitions that can be mapped to
+     * the AuthZ rules of an existing SystemOperation/TypeOperation.
+     *
+     * For example, the $docref operation from US Core is effectively a 'search-type' operation on 'DocumentReference'.
+     */
+    requestInformation: {
+        operation: TypeOperation | SystemOperation;
+        resourceType?: string;
+        id?: string;
+        vid?: string;
+    };
+    /**
+     * express router that contains the implementation of the operation. It will be mounted on "/"
+     */
+    router: Router;
+}

--- a/src/operationDefinitions/types.ts
+++ b/src/operationDefinitions/types.ts
@@ -5,12 +5,29 @@
 
 import { Router } from 'express';
 import { SystemOperation, TypeOperation } from 'fhir-works-on-aws-interface';
+import ResourceHandler from '../router/handlers/resourceHandler';
 
 export interface OperationDefinitionImplementation {
     /**
      * url of the corresponding OperationDefinition resource
      */
-    canonicalUrl: string;
+    readonly canonicalUrl: string;
+
+    /**
+     * url path used to invoke the operation
+     * @example '/DocumentReference/$docref'
+     */
+    readonly path: string;
+
+    /**
+     * Http verbs (methods) supported by this operation e.g GET, POST
+     */
+    readonly httpVerbs: string[];
+
+    /**
+     * FHIR resourceType that is affected by this operation
+     */
+    readonly targetResourceType: string;
 
     /**
      * Request information used to resolve AuthZ. This is applicable to OperationDefinitions that can be mapped to
@@ -18,7 +35,7 @@ export interface OperationDefinitionImplementation {
      *
      * For example, the $docref operation from US Core is effectively a 'search-type' operation on 'DocumentReference'.
      */
-    requestInformation: {
+    readonly requestInformation: {
         operation: TypeOperation | SystemOperation;
         resourceType?: string;
         id?: string;
@@ -27,5 +44,5 @@ export interface OperationDefinitionImplementation {
     /**
      * express router that contains the implementation of the operation. It will be mounted on "/"
      */
-    router: Router;
+    buildRouter(resourceHandler: ResourceHandler): Router;
 }

--- a/src/operationDefinitions/types.ts
+++ b/src/operationDefinitions/types.ts
@@ -14,6 +14,17 @@ export interface OperationDefinitionImplementation {
     readonly canonicalUrl: string;
 
     /**
+     * common name for the operation. It is found as `code` or `id` in the corresponding OperationDefinition resource
+     */
+    readonly name: string;
+
+    /**
+     * Usually based on the `description` of the corresponding OperationDefinition resource.
+     * documentation should also include details that are specific to this implementation of the operation
+     */
+    readonly documentation: string;
+
+    /**
      * url path used to invoke the operation
      * @example '/DocumentReference/$docref'
      */

--- a/src/registry/index.ts
+++ b/src/registry/index.ts
@@ -16,7 +16,9 @@ export class FHIRStructureDefinitionRegistry {
         let compiledStructureDefinitions: FhirStructureDefinition[] = [];
 
         if (compiledImplementationGuides !== undefined) {
-            compiledStructureDefinitions = [...compiledImplementationGuides];
+            compiledStructureDefinitions = [
+                ...compiledImplementationGuides.filter(x => x.resourceType === 'StructureDefinition'),
+            ];
         }
 
         this.capabilityStatement = {};

--- a/src/router/metadata/cap.rest.resource.template.ts
+++ b/src/router/metadata/cap.rest.resource.template.ts
@@ -11,6 +11,10 @@ import {
     Resource,
 } from 'fhir-works-on-aws-interface';
 import { ResourceCapabilityStatement, ResourceCapability } from '../../registry/ResourceCapabilityInterface';
+import {
+    OperationCapability,
+    OperationCapabilityStatement,
+} from '../../operationDefinitions/OperationDefinitionRegistry';
 
 function makeResourceObject(
     resourceType: string,
@@ -19,6 +23,7 @@ function makeResourceObject(
     hasTypeSearch: boolean,
     searchCapabilities?: SearchCapabilities,
     resourceCapability?: ResourceCapability,
+    operationCapability?: OperationCapability,
 ) {
     const result: any = {
         type: resourceType,
@@ -40,6 +45,10 @@ function makeResourceObject(
         Object.assign(result, resourceCapability);
     }
 
+    if (operationCapability) {
+        Object.assign(result, operationCapability);
+    }
+
     return result;
 }
 
@@ -58,6 +67,7 @@ export function makeGenericResources(
     operations: TypeOperation[],
     searchCapabilityStatement: SearchCapabilityStatement,
     resourceCapabilityStatement: ResourceCapabilityStatement,
+    operationCapabilityStatement: OperationCapabilityStatement,
     updateCreate: boolean,
 ) {
     const resources: any[] = [];
@@ -74,6 +84,7 @@ export function makeGenericResources(
                 hasTypeSearch,
                 searchCapabilityStatement[resourceType],
                 resourceCapabilityStatement[resourceType],
+                operationCapabilityStatement[resourceType],
             ),
         );
     });

--- a/src/router/metadata/metadataHandler.ts
+++ b/src/router/metadata/metadataHandler.ts
@@ -11,6 +11,7 @@ import makeRest from './cap.rest.template';
 import makeStatement from './cap.template';
 import ConfigHandler from '../../configHandler';
 import { FHIRStructureDefinitionRegistry } from '../../registry';
+import { OperationDefinitionRegistry } from '../../operationDefinitions/OperationDefinitionRegistry';
 
 export default class MetadataHandler implements Capabilities {
     configHandler: ConfigHandler;
@@ -19,10 +20,18 @@ export default class MetadataHandler implements Capabilities {
 
     readonly registry: FHIRStructureDefinitionRegistry;
 
-    constructor(handler: ConfigHandler, registry: FHIRStructureDefinitionRegistry, hasCORSEnabled: boolean = false) {
+    readonly operationRegistry: OperationDefinitionRegistry;
+
+    constructor(
+        handler: ConfigHandler,
+        registry: FHIRStructureDefinitionRegistry,
+        operationRegistry: OperationDefinitionRegistry,
+        hasCORSEnabled: boolean = false,
+    ) {
         this.configHandler = handler;
         this.hasCORSEnabled = hasCORSEnabled;
         this.registry = registry;
+        this.operationRegistry = operationRegistry;
     }
 
     private async generateResources(fhirVersion: FhirVersion) {
@@ -36,6 +45,7 @@ export default class MetadataHandler implements Capabilities {
                 this.configHandler.getGenericOperations(fhirVersion),
                 await this.configHandler.config.profile.genericResource.typeSearch.getCapabilities(),
                 await this.registry.getCapabilities(),
+                await this.operationRegistry.getCapabilities(),
                 updateCreate,
             );
         }

--- a/src/router/routes/metadataRoute.ts
+++ b/src/router/routes/metadataRoute.ts
@@ -8,6 +8,7 @@ import { CapabilityMode, FhirVersion } from 'fhir-works-on-aws-interface';
 import MetadataHandler from '../metadata/metadataHandler';
 import ConfigHandler from '../../configHandler';
 import { FHIRStructureDefinitionRegistry } from '../../registry';
+import { OperationDefinitionRegistry } from '../../operationDefinitions/OperationDefinitionRegistry';
 
 export default class MetadataRoute {
     readonly fhirVersion: FhirVersion;
@@ -20,10 +21,11 @@ export default class MetadataRoute {
         fhirVersion: FhirVersion,
         fhirConfigHandler: ConfigHandler,
         registry: FHIRStructureDefinitionRegistry,
+        operationRegistry: OperationDefinitionRegistry,
         hasCORSEnabled: boolean,
     ) {
         this.fhirVersion = fhirVersion;
-        this.metadataHandler = new MetadataHandler(fhirConfigHandler, registry, hasCORSEnabled);
+        this.metadataHandler = new MetadataHandler(fhirConfigHandler, registry, operationRegistry, hasCORSEnabled);
         this.router = express.Router();
         this.init();
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -877,7 +877,7 @@ acorn@^7.1.1:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.4.1.tgz#feaed255973d2e77555b83dbc08851a6c63520fa"
   integrity sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==
 
-ajv-errors@1.x:
+ajv-errors@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/ajv-errors/-/ajv-errors-1.0.1.tgz#f35986aceb91afadec4102fbd85014950cefa64d"
   integrity sha512-DCRfO/4nQ+89p/RK43i8Ezd41EqdGIU4ld7nGF8OQ14oc/we5rEntLCUa7+jrn3nn83BosfwZA0wb4pon2o8iQ==

--- a/yarn.lock
+++ b/yarn.lock
@@ -877,6 +877,11 @@ acorn@^7.1.1:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.4.1.tgz#feaed255973d2e77555b83dbc08851a6c63520fa"
   integrity sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==
 
+ajv-errors@1.x:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/ajv-errors/-/ajv-errors-1.0.1.tgz#f35986aceb91afadec4102fbd85014950cefa64d"
+  integrity sha512-DCRfO/4nQ+89p/RK43i8Ezd41EqdGIU4ld7nGF8OQ14oc/we5rEntLCUa7+jrn3nn83BosfwZA0wb4pon2o8iQ==
+
 ajv@^6.10.0, ajv@^6.10.2, ajv@^6.11.0, ajv@^6.12.3:
   version "6.12.6"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.6.tgz#baf5a62e802b07d977034586f8c3baf5adf26df4"


### PR DESCRIPTION
This is the final merge of the docref feature branch to mainline. All changes here have already been reviewed in previous PRs: #78 , #83 , #85 

Edit: The only new change is: https://github.com/awslabs/fhir-works-on-aws-routing/pull/86/commits/cd74f477556a2cd3899d81bed1dbdd30a62b1933. It is a minor change to follow the updated interface that now requires to pass along the `RequestContext` to `typeSearch`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.