### PR TITLE
chore(release): 5.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [5.4.1](https://github.com/awslabs/fhir-works-on-aws-routing/compare/v5.4.0...v5.4.1) (2021-05-21)
+
 ## [5.4.0](https://github.com/awslabs/fhir-works-on-aws-routing/compare/v5.3.0...v5.4.0) (2021-05-21)
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fhir-works-on-aws-routing",
-  "version": "5.4.0",
+  "version": "5.4.1",
   "description": "FHIR Works on AWS routing implementation",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",


### PR DESCRIPTION
There's nothing in this release. We just need to bump the version to republish to npm.

the package published to 5.4.0 has a tiny error. The casing of a folder name does not exactly match how it is imported (`USCoreDocRef` vs `USCoreDocref`). Depending on where the code runs it may cause import module issues (i.e. mac doesn't care, Amazon Linux does)
```
Error: Cannot find module './USCoreDocRef'
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.