### PR TITLE
fix: remove informational HTTP header

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -61,6 +61,7 @@ export function generateServerlessRouter(
     const operationRegistry = initializeOperationRegistry(configHandler);
 
     const app = express();
+    app.disable('x-powered-by');
     app.use(express.urlencoded({ extended: true }));
     app.use(
         express.json({


### PR DESCRIPTION
Description of changes: Remove informational header as it is unneeded by clients. More information here: https://www.troyhunt.com/shhh-dont-let-your-response-headers/

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.