### PR TITLE
refactor: remove usages of req.baseUrl

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -62,8 +62,11 @@ export function generateServerlessRouter(
 
     const app = express();
     app.disable('x-powered-by');
-    app.use(express.urlencoded({ extended: true }));
-    app.use(
+
+    const mainRouter = express.Router();
+
+    mainRouter.use(express.urlencoded({ extended: true }));
+    mainRouter.use(
         express.json({
             type: ['application/json', 'application/fhir+json', 'application/json-patch+json'],
             // 6MB is the maximum payload that Lambda accepts
@@ -72,7 +75,7 @@ export function generateServerlessRouter(
     );
     // Add cors handler before auth to allow pre-flight requests without auth.
     if (corsOptions) {
-        app.use(cors(corsOptions));
+        mainRouter.use(cors(corsOptions));
         hasCORSEnabled = true;
     }
 
@@ -84,19 +87,19 @@ export function generateServerlessRouter(
         operationRegistry,
         hasCORSEnabled,
     );
-    app.use('/metadata', metadataRoute.router);
+    mainRouter.use('/metadata', metadataRoute.router);
 
     if (fhirConfig.auth.strategy.service === 'SMART-on-FHIR') {
         // well-known URI http://www.hl7.org/fhir/smart-app-launch/conformance/index.html#using-well-known
         const smartStrat: SmartStrategy = fhirConfig.auth.strategy.oauthPolicy as SmartStrategy;
         if (smartStrat.capabilities) {
             const wellKnownUriRoute = new WellKnownUriRouteRoute(smartStrat);
-            app.use('/.well-known/smart-configuration', wellKnownUriRoute.router);
+            mainRouter.use('/.well-known/smart-configuration', wellKnownUriRoute.router);
         }
     }
 
     // AuthZ
-    app.use(async (req: express.Request, res: express.Response, next: express.NextFunction) => {
+    mainRouter.use(async (req: express.Request, res: express.Response, next: express.NextFunction) => {
         try {
             const requestInformation =
                 operationRegistry.getOperation(req.method, req.path)?.requestInformation ??
@@ -122,12 +125,12 @@ export function generateServerlessRouter(
             fhirConfig.profile.bulkDataAccess,
             fhirConfig.auth.authorization,
         );
-        app.use('/', exportRoute.router);
+        mainRouter.use('/', exportRoute.router);
     }
 
     // Operations defined by OperationDefinition resources
     operationRegistry.getAllRouters().forEach(router => {
-        app.use('/', router);
+        mainRouter.use('/', router);
     });
 
     // Special Resources
@@ -149,7 +152,7 @@ export function generateServerlessRouter(
                     resourceHandler,
                     fhirConfig.auth.authorization,
                 );
-                app.use(`/${resourceEntry[0]}`, route.router);
+                mainRouter.use(`/:resourceType(${resourceEntry[0]})`, route.router);
             }
         });
     }
@@ -177,7 +180,7 @@ export function generateServerlessRouter(
 
         // Set up Resource for each generic resource
         genericFhirResources.forEach(async (resourceType: string) => {
-            app.use(`/${resourceType}`, genericRoute.router);
+            mainRouter.use(`/:resourceType(${resourceType})`, genericRoute.router);
         });
     }
 
@@ -195,12 +198,14 @@ export function generateServerlessRouter(
             genericResource,
             fhirConfig.profile.resources,
         );
-        app.use('/', rootRoute.router);
+        mainRouter.use('/', rootRoute.router);
     }
 
-    app.use(applicationErrorMapper);
-    app.use(httpErrorHandler);
-    app.use(unknownErrorHandler);
+    mainRouter.use(applicationErrorMapper);
+    mainRouter.use(httpErrorHandler);
+    mainRouter.use(unknownErrorHandler);
+
+    app.use('/', mainRouter);
 
     return app;
 }

--- a/src/router/routes/genericResourceRoute.ts
+++ b/src/router/routes/genericResourceRoute.ts
@@ -22,7 +22,7 @@ export default class GenericResourceRoute {
     constructor(operations: TypeOperation[], handler: CrudHandlerInterface, authService: Authorization) {
         this.operations = operations;
         this.handler = handler;
-        this.router = express.Router();
+        this.router = express.Router({ mergeParams: true });
         this.authService = authService;
         this.init();
     }
@@ -35,8 +35,7 @@ export default class GenericResourceRoute {
                 '/:id',
                 RouteHelper.wrapAsync(async (req: express.Request, res: express.Response) => {
                     // Get the ResourceType looks like '/Patient'
-                    const resourceType = req.baseUrl.substr(1);
-                    const { id } = req.params;
+                    const { id, resourceType } = req.params;
                     const response = await this.handler.read(resourceType, id);
                     const updatedReadResponse = await this.authService.authorizeAndFilterReadResponse({
                         operation: 'read',
@@ -61,8 +60,7 @@ export default class GenericResourceRoute {
                 '/:id/_history/:vid',
                 RouteHelper.wrapAsync(async (req: express.Request, res: express.Response) => {
                     // Get the ResourceType looks like '/Patient'
-                    const resourceType = req.baseUrl.substr(1);
-                    const { id, vid } = req.params;
+                    const { id, vid, resourceType } = req.params;
                     const response = await this.handler.vRead(resourceType, id, vid);
                     const updatedReadResponse = await this.authService.authorizeAndFilterReadResponse({
                         operation: 'vread',
@@ -87,7 +85,7 @@ export default class GenericResourceRoute {
                 '/_history',
                 RouteHelper.wrapAsync(async (req: express.Request, res: express.Response) => {
                     // Get the ResourceType looks like '/Patient'
-                    const resourceType = req.baseUrl.substr(1);
+                    const { resourceType } = req.params;
                     const searchParamQuery = req.query;
                     const response = await this.handler.typeHistory(
                         resourceType,
@@ -112,9 +110,8 @@ export default class GenericResourceRoute {
                 '/:id/_history',
                 RouteHelper.wrapAsync(async (req: express.Request, res: express.Response) => {
                     // Get the ResourceType looks like '/Patient'
-                    const resourceType = req.baseUrl.substr(1);
                     const searchParamQuery = req.query;
-                    const { id } = req.params;
+                    const { id, resourceType } = req.params;
                     const response = await this.handler.instanceHistory(
                         resourceType,
                         id,
@@ -147,7 +144,7 @@ export default class GenericResourceRoute {
                 '/',
                 RouteHelper.wrapAsync(async (req: express.Request, res: express.Response) => {
                     // Get the ResourceType looks like '/Patient'
-                    const resourceType = req.baseUrl.substr(1);
+                    const { resourceType } = req.params;
                     const searchParamQuery = req.query;
                     const updatedSearchResponse = await handleSearch(res, resourceType, searchParamQuery);
                     res.send(updatedSearchResponse);
@@ -157,7 +154,7 @@ export default class GenericResourceRoute {
                 '/_search',
                 RouteHelper.wrapAsync(async (req: express.Request, res: express.Response) => {
                     // Get the ResourceType looks like '/Patient'
-                    const resourceType = req.baseUrl.substr(1);
+                    const { resourceType } = req.params;
                     const searchParamQuery = req.query;
                     const { body } = req;
 
@@ -186,7 +183,7 @@ export default class GenericResourceRoute {
                 '/',
                 RouteHelper.wrapAsync(async (req: express.Request, res: express.Response) => {
                     // Get the ResourceType looks like '/Patient'
-                    const resourceType = req.baseUrl.substr(1);
+                    const { resourceType } = req.params;
                     const { body } = req;
 
                     await this.authService.isWriteRequestAuthorized({
@@ -210,8 +207,7 @@ export default class GenericResourceRoute {
             this.router.put(
                 '/:id',
                 RouteHelper.wrapAsync(async (req: express.Request, res: express.Response) => {
-                    const resourceType = req.baseUrl.substr(1);
-                    const { id } = req.params;
+                    const { id, resourceType } = req.params;
                     const { body } = req;
 
                     if (body.id === null || body.id !== id) {
@@ -240,8 +236,7 @@ export default class GenericResourceRoute {
             this.router.patch(
                 '/:id',
                 RouteHelper.wrapAsync(async (req: express.Request, res: express.Response) => {
-                    const resourceType = req.baseUrl.substr(1);
-                    const { id } = req.params;
+                    const { id, resourceType } = req.params;
                     const { body } = req;
 
                     if (body.id && body.id !== id) {
@@ -271,8 +266,7 @@ export default class GenericResourceRoute {
                 '/:id',
                 RouteHelper.wrapAsync(async (req: express.Request, res: express.Response) => {
                     // Get the ResourceType looks like '/Patient'
-                    const resourceType = req.baseUrl.substr(1);
-                    const { id } = req.params;
+                    const { id, resourceType } = req.params;
                     const readResponse = await this.handler.read(resourceType, id);
 
                     await this.authService.isWriteRequestAuthorized({


### PR DESCRIPTION
Referencing `req.baseUrl` in nested routers is not great since mounting them on a different path often breaks them. This PR changes that.

Also added a `mainRouter` instead of using the default router from calling express `express()`. This makes it easier to mount the entire FHIR server on a different path (i.e. for tenant specific URLs)

Functionality is unchanged. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.