### PR TITLE
feat: pass tenantId to subcomponents. Allow tenant specific URLs

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -25,6 +25,8 @@ import ExportRoute from './router/routes/exportRoute';
 import WellKnownUriRouteRoute from './router/routes/wellKnownUriRoute';
 import { FHIRStructureDefinitionRegistry } from './registry';
 import { initializeOperationRegistry } from './operationDefinitions';
+import { setServerUrlMiddleware } from './router/middlewares/setServerUrl';
+import { setTenantIdMiddleware } from './router/middlewares/setTenantId';
 
 const configVersionSupported: ConfigVersion = 1;
 
@@ -63,7 +65,7 @@ export function generateServerlessRouter(
     const app = express();
     app.disable('x-powered-by');
 
-    const mainRouter = express.Router();
+    const mainRouter = express.Router({ mergeParams: true });
 
     mainRouter.use(express.urlencoded({ extended: true }));
     mainRouter.use(
@@ -78,6 +80,8 @@ export function generateServerlessRouter(
         mainRouter.use(cors(corsOptions));
         hasCORSEnabled = true;
     }
+
+    mainRouter.use(setServerUrlMiddleware(fhirConfig));
 
     // Metadata
     const metadataRoute: MetadataRoute = new MetadataRoute(
@@ -118,13 +122,13 @@ export function generateServerlessRouter(
         }
     });
 
+    if (fhirConfig.multiTenancyConfig?.enableMultiTenancy) {
+        mainRouter.use(setTenantIdMiddleware(fhirConfig));
+    }
+
     // Export
     if (fhirConfig.profile.bulkDataAccess) {
-        const exportRoute = new ExportRoute(
-            serverUrl,
-            fhirConfig.profile.bulkDataAccess,
-            fhirConfig.auth.authorization,
-        );
+        const exportRoute = new ExportRoute(fhirConfig.profile.bulkDataAccess, fhirConfig.auth.authorization);
         mainRouter.use('/', exportRoute.router);
     }
 
@@ -205,7 +209,11 @@ export function generateServerlessRouter(
     mainRouter.use(httpErrorHandler);
     mainRouter.use(unknownErrorHandler);
 
-    app.use('/', mainRouter);
+    if (fhirConfig.multiTenancyConfig?.enableMultiTenancy && fhirConfig.multiTenancyConfig?.useTenantSpecificUrl) {
+        app.use('/tenant/:tenantIdFromPath([a-zA-Z0-9\\-_]{1,64})', mainRouter);
+    } else {
+        app.use('/', mainRouter);
+    }
 
     return app;
 }

--- a/src/operationDefinitions/USCoreDocRef/index.ts
+++ b/src/operationDefinitions/USCoreDocRef/index.ts
@@ -19,9 +19,18 @@ const docRefImpl = async (
     userIdentity: KeyValueMap,
     params: DocRefParams,
     requestContext: RequestContext,
+    serverUrl: string,
+    tenantId?: string,
 ) => {
     const searchParams = convertDocRefParamsToSearchParams(params);
-    return resourceHandler.typeSearch('DocumentReference', searchParams, userIdentity, requestContext);
+    return resourceHandler.typeSearch(
+        'DocumentReference',
+        searchParams,
+        userIdentity,
+        requestContext,
+        serverUrl,
+        tenantId,
+    );
 };
 
 export const USCoreDocRef: OperationDefinitionImplementation = {
@@ -48,6 +57,8 @@ export const USCoreDocRef: OperationDefinitionImplementation = {
                     res.locals.userIdentity,
                     parseQueryParams(req.query),
                     res.locals.requestContext,
+                    res.locals.serverUrl,
+                    res.locals.tenantId,
                 );
                 res.send(response);
             }),
@@ -61,6 +72,8 @@ export const USCoreDocRef: OperationDefinitionImplementation = {
                     res.locals.userIdentity,
                     parsePostParams(req.body),
                     res.locals.requestContext,
+                    res.locals.serverUrl,
+                    res.locals.tenantId,
                 );
                 res.send(response);
             }),

--- a/src/router/handlers/CrudHandlerInterface.ts
+++ b/src/router/handlers/CrudHandlerInterface.ts
@@ -6,18 +6,27 @@
 import { KeyValueMap, RequestContext } from 'fhir-works-on-aws-interface';
 
 export default interface CrudHandlerInterface {
-    create(resourceType: string, resource: any): any;
-    update(resourceType: string, id: string, resource: any): any;
-    patch(resourceType: string, id: string, resource: any): any;
-    read(resourceType: string, id: string): any;
-    vRead(resourceType: string, id: string, vid: string): any;
-    delete(resourceType: string, id: string): any;
-    typeSearch(resourceType: string, searchParams: any, userIdentity: KeyValueMap, requestContext: RequestContext): any;
+    create(resourceType: string, resource: any, tenantId?: string): any;
+    update(resourceType: string, id: string, resource: any, tenantId?: string): any;
+    patch(resourceType: string, id: string, resource: any, tenantId?: string): any;
+    read(resourceType: string, id: string, tenantId?: string): any;
+    vRead(resourceType: string, id: string, vid: string, tenantId?: string): any;
+    delete(resourceType: string, id: string, tenantId?: string): any;
+    typeSearch(
+        resourceType: string,
+        searchParams: any,
+        userIdentity: KeyValueMap,
+        requestContext: RequestContext,
+        serverUrl: string,
+        tenantId?: string,
+    ): any;
     typeHistory(
         resourceType: string,
         searchParams: any,
         userIdentity: KeyValueMap,
         requestContext: RequestContext,
+        serverUrl: string,
+        tenantId?: string,
     ): any;
     instanceHistory(
         resourceType: string,
@@ -25,5 +34,7 @@ export default interface CrudHandlerInterface {
         searchParams: any,
         userIdentity: KeyValueMap,
         requestContext: RequestContext,
+        serverUrl: string,
+        tenantId?: string,
     ): any;
 }

--- a/src/router/handlers/exportHandler.ts
+++ b/src/router/handlers/exportHandler.ts
@@ -32,14 +32,20 @@ export default class ExportHandler {
         jobId: string,
         userIdentity: KeyValueMap,
         requestContext: RequestContext,
+        tenantId?: string,
     ): Promise<GetExportStatusResponse> {
-        const jobDetails = await this.bulkDataAccess.getExportStatus(jobId);
+        const jobDetails = await this.bulkDataAccess.getExportStatus(jobId, tenantId);
         await this.checkIfRequesterHasAccessToJob(jobDetails, userIdentity, requestContext);
         return jobDetails;
     }
 
-    async cancelExport(jobId: string, userIdentity: KeyValueMap, requestContext: RequestContext): Promise<void> {
-        const jobDetails = await this.bulkDataAccess.getExportStatus(jobId);
+    async cancelExport(
+        jobId: string,
+        userIdentity: KeyValueMap,
+        requestContext: RequestContext,
+        tenantId?: string,
+    ): Promise<void> {
+        const jobDetails = await this.bulkDataAccess.getExportStatus(jobId, tenantId);
         await this.checkIfRequesterHasAccessToJob(jobDetails, userIdentity, requestContext);
         if (['completed', 'failed'].includes(jobDetails.jobStatus)) {
             throw new createError.BadRequest(
@@ -47,7 +53,7 @@ export default class ExportHandler {
             );
         }
 
-        await this.bulkDataAccess.cancelExport(jobId);
+        await this.bulkDataAccess.cancelExport(jobId, tenantId);
     }
 
     private async checkIfRequesterHasAccessToJob(

--- a/src/router/handlers/resourceHandler.test.ts
+++ b/src/router/handlers/resourceHandler.test.ts
@@ -402,6 +402,7 @@ describe('Testing search', () => {
             { name: 'Henry' },
             {},
             dummyRequestContext,
+            'https://API_URL.com',
         );
 
         // CHECK
@@ -457,6 +458,7 @@ describe('Testing search', () => {
             { name: 'Henry' },
             {},
             dummyRequestContext,
+            'https://API_URL.com',
         );
 
         // CHECK
@@ -481,7 +483,13 @@ describe('Testing search', () => {
         ElasticSearchService.typeSearch = jest.fn().mockRejectedValue(new Error('Boom!!'));
         try {
             // OPERATE
-            await resourceHandler.typeSearch('Patient', { name: 'Henry' }, {}, dummyRequestContext);
+            await resourceHandler.typeSearch(
+                'Patient',
+                { name: 'Henry' },
+                {},
+                dummyRequestContext,
+                'https://API_URL.com',
+            );
         } catch (e) {
             // CHECK
             expect(e).toEqual(new Error('Boom!!'));
@@ -518,6 +526,7 @@ describe('Testing search', () => {
                 },
                 {},
                 dummyRequestContext,
+                'https://API_URL.com',
             );
 
             // CHECK
@@ -575,6 +584,7 @@ describe('Testing search', () => {
                 },
                 {},
                 dummyRequestContext,
+                'https://API_URL.com',
             );
 
             // CHECK
@@ -632,6 +642,7 @@ describe('Testing search', () => {
                 },
                 {},
                 dummyRequestContext,
+                'https://API_URL.com',
             );
 
             // CHECK
@@ -712,6 +723,7 @@ describe('Testing history', () => {
             { name: 'Henry' },
             {},
             dummyRequestContext,
+            'https://API_URL.com',
         );
 
         // CHECK
@@ -753,6 +765,7 @@ describe('Testing history', () => {
             { name: 'Henry' },
             {},
             dummyRequestContext,
+            'https://API_URL.com',
         );
 
         // CHECK
@@ -777,7 +790,13 @@ describe('Testing history', () => {
         stubs.history.typeHistory = jest.fn().mockRejectedValue(new Error('Boom!!'));
         try {
             // OPERATE
-            await resourceHandler.typeHistory('Patient', { name: 'Henry' }, {}, dummyRequestContext);
+            await resourceHandler.typeHistory(
+                'Patient',
+                { name: 'Henry' },
+                {},
+                dummyRequestContext,
+                'https://API_URL.com',
+            );
         } catch (e) {
             // CHECK
             expect(e).toEqual(new Error('Boom!!'));
@@ -809,6 +828,7 @@ describe('Testing history', () => {
             { name: 'Henry' },
             {},
             dummyRequestContext,
+            'https://API_URL.com',
         );
 
         // CHECK
@@ -840,7 +860,14 @@ describe('Testing history', () => {
         stubs.history.instanceHistory = jest.fn().mockRejectedValue(new Error('Boom!!'));
         try {
             // OPERATE
-            await resourceHandler.instanceHistory('Patient', 'id123', { name: 'Henry' }, {}, dummyRequestContext);
+            await resourceHandler.instanceHistory(
+                'Patient',
+                'id123',
+                { name: 'Henry' },
+                {},
+                dummyRequestContext,
+                'https://API_URL.com',
+            );
         } catch (e) {
             // CHECK
             expect(e).toEqual(new Error('Boom!!'));
@@ -877,6 +904,7 @@ describe('Testing history', () => {
                 },
                 {},
                 dummyRequestContext,
+                'https://API_URL.com',
             );
 
             // CHECK
@@ -934,6 +962,7 @@ describe('Testing history', () => {
                 },
                 {},
                 dummyRequestContext,
+                'https://API_URL.com',
             );
 
             // CHECK
@@ -992,6 +1021,7 @@ describe('Testing history', () => {
                 },
                 {},
                 dummyRequestContext,
+                'https://API_URL.com',
             );
 
             // CHECK

--- a/src/router/handlers/rootHandler.ts
+++ b/src/router/handlers/rootHandler.ts
@@ -22,7 +22,7 @@ export default class RootHandler {
         this.serverUrl = serverUrl;
     }
 
-    async globalSearch(queryParams: any, userIdentity: KeyValueMap, requestContext: RequestContext) {
+    async globalSearch(queryParams: any, userIdentity: KeyValueMap, requestContext: RequestContext, tenantId?: string) {
         const searchFilters = await this.authService.getSearchFilterBasedOnIdentity({
             userIdentity,
             requestContext,
@@ -32,11 +32,17 @@ export default class RootHandler {
             queryParams,
             baseUrl: this.serverUrl,
             searchFilters,
+            tenantId,
         });
         return BundleGenerator.generateBundle(this.serverUrl, queryParams, searchResponse.result, 'searchset');
     }
 
-    async globalHistory(queryParams: any, userIdentity: KeyValueMap, requestContext: RequestContext) {
+    async globalHistory(
+        queryParams: any,
+        userIdentity: KeyValueMap,
+        requestContext: RequestContext,
+        tenantId?: string,
+    ) {
         const searchFilters = await this.authService.getSearchFilterBasedOnIdentity({
             userIdentity,
             requestContext,
@@ -46,6 +52,7 @@ export default class RootHandler {
             queryParams,
             baseUrl: this.serverUrl,
             searchFilters,
+            tenantId,
         });
         return BundleGenerator.generateBundle(this.serverUrl, queryParams, historyResponse.result, 'history');
     }

--- a/src/router/middlewares/setServerUrl.test.ts
+++ b/src/router/middlewares/setServerUrl.test.ts
@@ -1,0 +1,62 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+import { FhirConfig } from 'fhir-works-on-aws-interface';
+import express from 'express';
+import { setServerUrlMiddleware } from './setServerUrl';
+
+async function sleep(milliseconds: number) {
+    return new Promise(resolve => setTimeout(resolve, milliseconds));
+}
+
+describe('createServerUrlMiddleware', () => {
+    test('root baseUrl', async () => {
+        const fhirConfig = {
+            server: {
+                url: 'https://fwoa.com',
+            },
+        } as FhirConfig;
+
+        const serverUrlMiddleware = setServerUrlMiddleware(fhirConfig);
+
+        const nextMock = jest.fn();
+        const req = ({ baseUrl: '/' } as unknown) as express.Request;
+        const res = ({
+            locals: {},
+        } as unknown) as express.Response;
+
+        serverUrlMiddleware(req, res, nextMock);
+        await sleep(1);
+
+        expect(nextMock).toHaveBeenCalledTimes(1);
+        expect(nextMock).toHaveBeenCalledWith();
+        expect(res.locals.serverUrl).toEqual('https://fwoa.com');
+    });
+
+    test('path base url', async () => {
+        const fhirConfig = {
+            server: {
+                url: 'https://fwoa.com',
+            },
+        } as FhirConfig;
+
+        const serverUrlMiddleware = setServerUrlMiddleware(fhirConfig);
+
+        const nextMock = jest.fn();
+        const req = ({ baseUrl: '/some/path' } as unknown) as express.Request;
+        const res = ({
+            locals: {},
+        } as unknown) as express.Response;
+
+        serverUrlMiddleware(req, res, nextMock);
+        await sleep(1);
+
+        expect(nextMock).toHaveBeenCalledTimes(1);
+        expect(nextMock).toHaveBeenCalledWith();
+        expect(res.locals.serverUrl).toEqual('https://fwoa.com/some/path');
+    });
+});

--- a/src/router/middlewares/setServerUrl.ts
+++ b/src/router/middlewares/setServerUrl.ts
@@ -1,0 +1,27 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+import { FhirConfig } from 'fhir-works-on-aws-interface';
+import express from 'express';
+import RouteHelper from '../routes/routeHelper';
+
+/**
+ * Sets the value of `res.locals.serverUrl`
+ * the serverUrl can either be a static value from FhirConfig of a dynamic value for some multi-tenancy setups.
+ */
+export const setServerUrlMiddleware: (
+    fhirConfig: FhirConfig,
+) => (req: express.Request, res: express.Response, next: express.NextFunction) => void = (fhirConfig: FhirConfig) => {
+    return RouteHelper.wrapAsync(async (req: express.Request, res: express.Response, next: express.NextFunction) => {
+        if (req.baseUrl && req.baseUrl !== '/') {
+            res.locals.serverUrl = fhirConfig.server.url + req.baseUrl;
+        } else {
+            res.locals.serverUrl = fhirConfig.server.url;
+        }
+        next();
+    });
+};

--- a/src/router/middlewares/setTenantId.test.ts
+++ b/src/router/middlewares/setTenantId.test.ts
@@ -1,0 +1,163 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+import { FhirConfig, UnauthorizedError } from 'fhir-works-on-aws-interface';
+import express from 'express';
+import { setTenantIdMiddleware } from './setTenantId';
+
+async function sleep(milliseconds: number) {
+    return new Promise(resolve => setTimeout(resolve, milliseconds));
+}
+
+describe('SetTenantIdMiddleware', () => {
+    describe('success cases', () => {
+        test('simple tenantId claim', async () => {
+            const fhirConfig = {
+                multiTenancyConfig: {
+                    enableMultiTenancy: true,
+                    tenantIdClaimPath: 'tenantId',
+                },
+            } as FhirConfig;
+
+            const setTenantIdMiddlewareFn = setTenantIdMiddleware(fhirConfig);
+            const nextMock = jest.fn();
+            const req = ({ params: {} } as unknown) as express.Request;
+            const res = ({
+                locals: {
+                    userIdentity: {
+                        claim1: 'val1',
+                        tenantId: 't1',
+                    },
+                },
+            } as unknown) as express.Response;
+
+            setTenantIdMiddlewareFn(req, res, nextMock);
+
+            await sleep(1);
+
+            expect(nextMock).toHaveBeenCalledTimes(1);
+            expect(nextMock).toHaveBeenCalledWith();
+            expect(res.locals.tenantId).toEqual('t1');
+        });
+
+        test('nested tenantId claim', async () => {
+            const fhirConfig = {
+                multiTenancyConfig: {
+                    enableMultiTenancy: true,
+                    tenantIdClaimPath: 'obj.tenantId',
+                },
+            } as FhirConfig;
+
+            const setTenantIdMiddlewareFn = setTenantIdMiddleware(fhirConfig);
+            const nextMock = jest.fn();
+            const req = ({ params: {} } as unknown) as express.Request;
+            const res = ({
+                locals: {
+                    userIdentity: {
+                        claim1: 'val1',
+                        obj: {
+                            tenantId: 't1',
+                        },
+                    },
+                },
+            } as unknown) as express.Response;
+
+            setTenantIdMiddlewareFn(req, res, nextMock);
+
+            await sleep(1);
+
+            expect(nextMock).toHaveBeenCalledTimes(1);
+            expect(nextMock).toHaveBeenCalledWith();
+            expect(res.locals.tenantId).toEqual('t1');
+        });
+    });
+
+    describe('error cases', () => {
+        test('bad path', async () => {
+            const fhirConfig = {
+                multiTenancyConfig: {
+                    enableMultiTenancy: true,
+                    tenantIdClaimPath: 'somePathThatIsNotInTheToken',
+                },
+            } as FhirConfig;
+
+            const setTenantIdMiddlewareFn = setTenantIdMiddleware(fhirConfig);
+            const nextMock = jest.fn();
+            const req = ({ params: {} } as unknown) as express.Request;
+            const res = ({
+                locals: {
+                    userIdentity: {
+                        claim1: 'val1',
+                        tenantId: 't1',
+                    },
+                },
+            } as unknown) as express.Response;
+
+            setTenantIdMiddlewareFn(req, res, nextMock);
+
+            await sleep(1);
+
+            expect(nextMock).toHaveBeenCalledTimes(1);
+            expect(nextMock).toHaveBeenCalledWith(new UnauthorizedError('Unauthorized'));
+        });
+
+        test('invalidTenantId', async () => {
+            const fhirConfig = {
+                multiTenancyConfig: {
+                    enableMultiTenancy: true,
+                    tenantIdClaimPath: 'tenantId',
+                },
+            } as FhirConfig;
+
+            const setTenantIdMiddlewareFn = setTenantIdMiddleware(fhirConfig);
+            const nextMock = jest.fn();
+            const req = ({ params: {} } as unknown) as express.Request;
+            const res = ({
+                locals: {
+                    userIdentity: {
+                        claim1: 'val1',
+                        tenantId: 'InvalidTenantId_#$%&*?',
+                    },
+                },
+            } as unknown) as express.Response;
+
+            setTenantIdMiddlewareFn(req, res, nextMock);
+
+            await sleep(1);
+
+            expect(nextMock).toHaveBeenCalledTimes(1);
+            expect(nextMock).toHaveBeenCalledWith(new UnauthorizedError('Unauthorized'));
+        });
+
+        test('tenantId in token does not match tenantId in token', async () => {
+            const fhirConfig = {
+                multiTenancyConfig: {
+                    enableMultiTenancy: true,
+                    tenantIdClaimPath: 'tenantId',
+                },
+            } as FhirConfig;
+
+            const setTenantIdMiddlewareFn = setTenantIdMiddleware(fhirConfig);
+            const nextMock = jest.fn();
+            const req = ({ params: { tenantIdFromPath: 't2' } } as unknown) as express.Request;
+            const res = ({
+                locals: {
+                    userIdentity: {
+                        claim1: 'val1',
+                        tenantId: 't1',
+                    },
+                },
+            } as unknown) as express.Response;
+
+            setTenantIdMiddlewareFn(req, res, nextMock);
+
+            await sleep(1);
+
+            expect(nextMock).toHaveBeenCalledTimes(1);
+            expect(nextMock).toHaveBeenCalledWith(new UnauthorizedError('Unauthorized'));
+        });
+    });
+});

--- a/src/router/middlewares/setTenantId.ts
+++ b/src/router/middlewares/setTenantId.ts
@@ -1,0 +1,33 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+import { FhirConfig, UnauthorizedError } from 'fhir-works-on-aws-interface';
+import express from 'express';
+import { get } from 'lodash';
+import RouteHelper from '../routes/routeHelper';
+
+const tenantIdRegex = /^[a-zA-Z0-9\-_]{1,64}$/;
+
+/**
+ * Sets the value of `res.locals.tenantId`
+ * tenantId is used to identify tenants in a multi-tenant setup
+ */
+export const setTenantIdMiddleware: (
+    fhirConfig: FhirConfig,
+) => (req: express.Request, res: express.Response, next: express.NextFunction) => void = (fhirConfig: FhirConfig) => {
+    return RouteHelper.wrapAsync(async (req: express.Request, res: express.Response, next: express.NextFunction) => {
+        const tenantId = get(res.locals.userIdentity, fhirConfig.multiTenancyConfig?.tenantIdClaimPath!);
+        if (
+            tenantId === undefined ||
+            !tenantIdRegex.test(tenantId) ||
+            (req.params.tenantIdFromPath !== undefined && req.params.tenantIdFromPath !== tenantId)
+        ) {
+            throw new UnauthorizedError('Unauthorized');
+        }
+        res.locals.tenantId = tenantId;
+        next();
+    });
+};

--- a/src/router/routes/exportRouteHelper.ts
+++ b/src/router/routes/exportRouteHelper.ts
@@ -34,6 +34,7 @@ export default class ExportRouteHelper {
                     : undefined,
             type: isString(req.query._type) ? req.query._type : undefined,
             groupId: isString(req.params.id) ? req.params.id : undefined,
+            tenantId: res.locals.tenantId,
         };
         return initiateExportRequest;
     }
@@ -46,14 +47,15 @@ export default class ExportRouteHelper {
     ) {
         const { outputFormat, since, type } = queryParams;
         const url = new URL(baseUrl);
+        url.pathname += url.pathname.endsWith('/') ? '' : '/';
         if (exportType === 'system') {
-            url.pathname = '/$export';
+            url.pathname += '$export';
         }
         if (exportType === 'patient') {
-            url.pathname = '/Patient/$export';
+            url.pathname += 'Patient/$export';
         }
         if (exportType === 'group') {
-            url.pathname = `/Group/${groupId}/$export`;
+            url.pathname += `Group/${groupId}/$export`;
         }
         if (outputFormat) {
             url.searchParams.append('_outputFormat', outputFormat);

--- a/src/router/routes/genericResourceRoute.ts
+++ b/src/router/routes/genericResourceRoute.ts
@@ -36,7 +36,7 @@ export default class GenericResourceRoute {
                 RouteHelper.wrapAsync(async (req: express.Request, res: express.Response) => {
                     // Get the ResourceType looks like '/Patient'
                     const { id, resourceType } = req.params;
-                    const response = await this.handler.read(resourceType, id);
+                    const response = await this.handler.read(resourceType, id, res.locals.tenantId);
                     const updatedReadResponse = await this.authService.authorizeAndFilterReadResponse({
                         operation: 'read',
                         userIdentity: res.locals.userIdentity,
@@ -61,7 +61,7 @@ export default class GenericResourceRoute {
                 RouteHelper.wrapAsync(async (req: express.Request, res: express.Response) => {
                     // Get the ResourceType looks like '/Patient'
                     const { id, vid, resourceType } = req.params;
-                    const response = await this.handler.vRead(resourceType, id, vid);
+                    const response = await this.handler.vRead(resourceType, id, vid, res.locals.tenantId);
                     const updatedReadResponse = await this.authService.authorizeAndFilterReadResponse({
                         operation: 'vread',
                         userIdentity: res.locals.userIdentity,
@@ -92,6 +92,7 @@ export default class GenericResourceRoute {
                         searchParamQuery,
                         res.locals.userIdentity,
                         res.locals.requestContext,
+                        res.locals.tenantId,
                     );
                     const updatedReadResponse = await this.authService.authorizeAndFilterReadResponse({
                         operation: 'history-type',
@@ -118,6 +119,7 @@ export default class GenericResourceRoute {
                         searchParamQuery,
                         res.locals.userIdentity,
                         res.locals.requestContext,
+                        res.locals.tenantId,
                     );
                     const updatedReadResponse = await this.authService.authorizeAndFilterReadResponse({
                         operation: 'history-instance',
@@ -137,6 +139,8 @@ export default class GenericResourceRoute {
                     searchParamQuery,
                     res.locals.userIdentity,
                     res.locals.requestContext,
+                    res.locals.serverUrl,
+                    res.locals.tenantId,
                 );
             };
             // SEARCH
@@ -193,7 +197,7 @@ export default class GenericResourceRoute {
                         requestContext: res.locals.requestContext,
                     });
 
-                    const response = await this.handler.create(resourceType, body);
+                    const response = await this.handler.create(resourceType, body, res.locals.tenantId);
                     if (response && response.meta) {
                         res.set({ ETag: `W/"${response.meta.versionId}"`, 'Last-Modified': response.meta.lastUpdated });
                     }
@@ -222,7 +226,7 @@ export default class GenericResourceRoute {
                         requestContext: res.locals.requestContext,
                     });
 
-                    const response = await this.handler.update(resourceType, id, body);
+                    const response = await this.handler.update(resourceType, id, body, res.locals.tenantId);
                     if (response && response.meta) {
                         res.set({ ETag: `W/"${response.meta.versionId}"`, 'Last-Modified': response.meta.lastUpdated });
                     }
@@ -251,7 +255,7 @@ export default class GenericResourceRoute {
                         requestContext: res.locals.requestContext,
                     });
 
-                    const response = await this.handler.patch(resourceType, id, body);
+                    const response = await this.handler.patch(resourceType, id, body, res.locals.tenantId);
                     if (response && response.meta) {
                         res.set({ ETag: `W/"${response.meta.versionId}"`, 'Last-Modified': response.meta.lastUpdated });
                     }
@@ -267,7 +271,7 @@ export default class GenericResourceRoute {
                 RouteHelper.wrapAsync(async (req: express.Request, res: express.Response) => {
                     // Get the ResourceType looks like '/Patient'
                     const { id, resourceType } = req.params;
-                    const readResponse = await this.handler.read(resourceType, id);
+                    const readResponse = await this.handler.read(resourceType, id, res.locals.tenantId);
 
                     await this.authService.isWriteRequestAuthorized({
                         resourceBody: readResponse,
@@ -276,7 +280,7 @@ export default class GenericResourceRoute {
                         requestContext: res.locals.requestContext,
                     });
 
-                    const response = await this.handler.delete(resourceType, id);
+                    const response = await this.handler.delete(resourceType, id, res.locals.tenantId);
                     res.send(response);
                 }),
             );

--- a/src/router/routes/rootRoute.ts
+++ b/src/router/routes/rootRoute.ts
@@ -96,6 +96,7 @@ export default class RootRoute {
                         searchParamQuery,
                         res.locals.userIdentity,
                         res.locals.requestContext,
+                        res.locals.tenantId,
                     );
                     const updatedReadResponse = await this.authService.authorizeAndFilterReadResponse({
                         operation: 'search-system',
@@ -116,6 +117,7 @@ export default class RootRoute {
                         searchParamQuery,
                         res.locals.userIdentity,
                         res.locals.requestContext,
+                        res.locals.tenantId,
                     );
                     const updatedReadResponse = await this.authService.authorizeAndFilterReadResponse({
                         operation: 'history-system',


### PR DESCRIPTION
Extract tenantId from the access token and pass it down to FWoA subcomponents. Also support tenant specific URLs such as
```
{{API_URL}}/tenant/tenant111/Patient
```


Notable changes:
- `src/router/middlewares/setTenantId.ts` extracts the tenantId from the access token and sets `res.locals.tenantId` for the rest of the application to use. 
The AuthZ components are unchanged, they only validate that the `tenantId` is legit by verifying the token signature.
- server url can not longer be statically set in class constructors, since it can differ for each tenant. `src/router/middlewares/setServerUrl.ts` resolves the `serverUrl` for the incoming request and sets in `res.locals` so that the rest of the application can reference it.

Most of the other code changes are just for passing `tenantId` to FWoA subcomponents.

**NOTE:** Unit tests won't pass since the interface changes are on a feature branch. They work fine locally.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.