### PR TITLE
feat: pass fhirServiceBaseUrl as param to authZ calls

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -115,6 +115,7 @@ export function generateServerlessRouter(
                 ...requestInformation,
                 requestContext: res.locals.requestContext,
                 accessToken: req.headers.authorization,
+                fhirServiceBaseUrl: res.locals.serverUrl,
             });
             next();
         } catch (e) {

--- a/src/router/bundle/bundleHandler.ts
+++ b/src/router/bundle/bundleHandler.ts
@@ -59,7 +59,7 @@ export default class BundleHandler implements BundleHandlerInterface {
     }
 
     // eslint-disable-next-line @typescript-eslint/no-unused-vars,prettier/prettier
-    async processBatch(bundleRequestJson: any, userIdentity: KeyValueMap, requestContext: RequestContext, tenantId?: string) {
+    async processBatch(bundleRequestJson: any, userIdentity: KeyValueMap, requestContext: RequestContext, serverUrl: string, tenantId?: string) {
         throw new createError.BadRequest('Currently this server only support transaction Bundles');
     }
 
@@ -102,6 +102,7 @@ export default class BundleHandler implements BundleHandlerInterface {
         bundleRequestJson: any,
         userIdentity: KeyValueMap,
         requestContext: RequestContext,
+        serverUrl: string,
         tenantId?: string,
     ) {
         const startTime = new Date();
@@ -171,6 +172,7 @@ export default class BundleHandler implements BundleHandlerInterface {
                     userIdentity,
                     requestContext,
                     readResponse: bundleServiceResponse.batchReadWriteResponses[index].resource,
+                    fhirServiceBaseUrl: serverUrl,
                 });
             }
             return Promise.resolve();

--- a/src/router/bundle/bundleHandlerInterface.ts
+++ b/src/router/bundle/bundleHandlerInterface.ts
@@ -5,11 +5,18 @@
 import { KeyValueMap, RequestContext } from 'fhir-works-on-aws-interface';
 
 export default interface BundleHandlerInterface {
-    processBatch(resource: any, userIdentity: KeyValueMap, requestContext: RequestContext, tenantId?: string): any;
+    processBatch(
+        resource: any,
+        userIdentity: KeyValueMap,
+        requestContext: RequestContext,
+        serverUrl: string,
+        tenantId?: string,
+    ): any;
     processTransaction(
         resource: any,
         userIdentity: KeyValueMap,
         requestContext: RequestContext,
+        serverUrl: string,
         tenantId?: string,
     ): any;
 }

--- a/src/router/handlers/resourceHandler.ts
+++ b/src/router/handlers/resourceHandler.ts
@@ -83,6 +83,7 @@ export default class ResourceHandler implements CrudHandlerInterface {
             requestContext,
             operation: 'search-type',
             resourceType,
+            fhirServiceBaseUrl: serverUrl,
         });
 
         const searchResponse = await this.searchService.typeSearch({
@@ -106,6 +107,7 @@ export default class ResourceHandler implements CrudHandlerInterface {
             userIdentity,
             requestContext,
             readResponse: bundle,
+            fhirServiceBaseUrl: serverUrl,
         });
     }
 
@@ -122,6 +124,7 @@ export default class ResourceHandler implements CrudHandlerInterface {
             requestContext,
             operation: 'history-type',
             resourceType,
+            fhirServiceBaseUrl: serverUrl,
         });
 
         const historyResponse = await this.historyService.typeHistory({
@@ -149,6 +152,7 @@ export default class ResourceHandler implements CrudHandlerInterface {
             operation: 'history-instance',
             resourceType,
             id,
+            fhirServiceBaseUrl: serverUrl,
         });
 
         const historyResponse = await this.historyService.instanceHistory({

--- a/src/router/handlers/rootHandler.ts
+++ b/src/router/handlers/rootHandler.ts
@@ -22,11 +22,18 @@ export default class RootHandler {
         this.serverUrl = serverUrl;
     }
 
-    async globalSearch(queryParams: any, userIdentity: KeyValueMap, requestContext: RequestContext, tenantId?: string) {
+    async globalSearch(
+        queryParams: any,
+        userIdentity: KeyValueMap,
+        requestContext: RequestContext,
+        serverUrl: string,
+        tenantId?: string,
+    ) {
         const searchFilters = await this.authService.getSearchFilterBasedOnIdentity({
             userIdentity,
             requestContext,
             operation: 'search-system',
+            fhirServiceBaseUrl: serverUrl,
         });
         const searchResponse = await this.searchService.globalSearch({
             queryParams,
@@ -41,12 +48,14 @@ export default class RootHandler {
         queryParams: any,
         userIdentity: KeyValueMap,
         requestContext: RequestContext,
+        serverUrl: string,
         tenantId?: string,
     ) {
         const searchFilters = await this.authService.getSearchFilterBasedOnIdentity({
             userIdentity,
             requestContext,
             operation: 'history-system',
+            fhirServiceBaseUrl: serverUrl,
         });
         const historyResponse = await this.historyService.globalHistory({
             queryParams,

--- a/src/router/routes/genericResourceRoute.ts
+++ b/src/router/routes/genericResourceRoute.ts
@@ -42,6 +42,7 @@ export default class GenericResourceRoute {
                         userIdentity: res.locals.userIdentity,
                         requestContext: res.locals.requestContext,
                         readResponse: response,
+                        fhirServiceBaseUrl: res.locals.serverUrl,
                     });
                     if (updatedReadResponse && updatedReadResponse.meta) {
                         res.set({
@@ -67,6 +68,7 @@ export default class GenericResourceRoute {
                         userIdentity: res.locals.userIdentity,
                         requestContext: res.locals.requestContext,
                         readResponse: response,
+                        fhirServiceBaseUrl: res.locals.serverUrl,
                     });
                     if (updatedReadResponse && updatedReadResponse.meta) {
                         res.set({
@@ -99,6 +101,7 @@ export default class GenericResourceRoute {
                         userIdentity: res.locals.userIdentity,
                         requestContext: res.locals.requestContext,
                         readResponse: response,
+                        fhirServiceBaseUrl: res.locals.serverUrl,
                     });
                     res.send(updatedReadResponse);
                 }),
@@ -126,6 +129,7 @@ export default class GenericResourceRoute {
                         userIdentity: res.locals.userIdentity,
                         requestContext: res.locals.requestContext,
                         readResponse: response,
+                        fhirServiceBaseUrl: res.locals.serverUrl,
                     });
                     res.send(updatedReadResponse);
                 }),
@@ -195,6 +199,7 @@ export default class GenericResourceRoute {
                         operation: 'create',
                         userIdentity: res.locals.userIdentity,
                         requestContext: res.locals.requestContext,
+                        fhirServiceBaseUrl: res.locals.serverUrl,
                     });
 
                     const response = await this.handler.create(resourceType, body, res.locals.tenantId);
@@ -224,6 +229,7 @@ export default class GenericResourceRoute {
                         operation: 'update',
                         userIdentity: res.locals.userIdentity,
                         requestContext: res.locals.requestContext,
+                        fhirServiceBaseUrl: res.locals.serverUrl,
                     });
 
                     const response = await this.handler.update(resourceType, id, body, res.locals.tenantId);
@@ -253,6 +259,7 @@ export default class GenericResourceRoute {
                         operation: 'patch',
                         userIdentity: res.locals.userIdentity,
                         requestContext: res.locals.requestContext,
+                        fhirServiceBaseUrl: res.locals.serverUrl,
                     });
 
                     const response = await this.handler.patch(resourceType, id, body, res.locals.tenantId);
@@ -278,6 +285,7 @@ export default class GenericResourceRoute {
                         operation: 'delete',
                         userIdentity: res.locals.userIdentity,
                         requestContext: res.locals.requestContext,
+                        fhirServiceBaseUrl: res.locals.serverUrl,
                     });
 
                     const response = await this.handler.delete(resourceType, id, res.locals.tenantId);

--- a/src/router/routes/rootRoute.ts
+++ b/src/router/routes/rootRoute.ts
@@ -69,6 +69,7 @@ export default class RootRoute {
                                 req.body,
                                 res.locals.userIdentity,
                                 res.locals.requestContext,
+                                res.locals.serverUrl,
                                 res.locals.tenantId,
                             );
                             res.send(response);
@@ -77,6 +78,7 @@ export default class RootRoute {
                                 req.body,
                                 res.locals.userIdentity,
                                 res.locals.requestContext,
+                                res.locals.serverUrl,
                                 res.locals.tenantId,
                             );
                             res.send(response);
@@ -98,6 +100,7 @@ export default class RootRoute {
                         searchParamQuery,
                         res.locals.userIdentity,
                         res.locals.requestContext,
+                        res.locals.serverUrl,
                         res.locals.tenantId,
                     );
                     const updatedReadResponse = await this.authService.authorizeAndFilterReadResponse({
@@ -105,6 +108,7 @@ export default class RootRoute {
                         userIdentity: res.locals.userIdentity,
                         requestContext: res.locals.requestContext,
                         readResponse: response,
+                        fhirServiceBaseUrl: res.locals.serverUrl,
                     });
                     res.send(updatedReadResponse);
                 }),
@@ -119,6 +123,7 @@ export default class RootRoute {
                         searchParamQuery,
                         res.locals.userIdentity,
                         res.locals.requestContext,
+                        res.locals.serverUrl,
                         res.locals.tenantId,
                     );
                     const updatedReadResponse = await this.authService.authorizeAndFilterReadResponse({
@@ -126,6 +131,7 @@ export default class RootRoute {
                         userIdentity: res.locals.userIdentity,
                         requestContext: res.locals.requestContext,
                         readResponse: response,
+                        fhirServiceBaseUrl: res.locals.serverUrl,
                     });
                     res.send(updatedReadResponse);
                 }),


### PR DESCRIPTION
Description of changes:

Just passing down `res.locals.serverUrl` as param to the different AuthZ calls. 

See: https://github.com/awslabs/fhir-works-on-aws-interface/pull/72


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.