### PR TITLE
fix: properly handle versioned references in BundleParser

### DIFF
--- a/src/router/__mocks__/dynamoDbDataService.ts
+++ b/src/router/__mocks__/dynamoDbDataService.ts
@@ -63,6 +63,9 @@ const DynamoDbDataService: Persistence = class {
     static async vReadResource(request: vReadResourceRequest): Promise<GenericResponse> {
         const resourceCopy: any = clone(validPatient);
         resourceCopy.id = request.id;
+        if (request.vid) {
+            expect(request.vid).toMatch(/^\d+$/);
+        }
         resourceCopy.meta = generateMeta(request.vid);
         return {
             message: 'Resource found',

--- a/src/router/bundle/bundleParser.test.ts
+++ b/src/router/bundle/bundleParser.test.ts
@@ -790,7 +790,8 @@ describe('parseResource', () => {
                                 reference: `${serverUrl}/Patient/111`,
                             },
                             device: {
-                                reference: `${serverUrl}/Device/222`,
+                                // make sure versioned references also work
+                                reference: `${serverUrl}/Device/222/_history/7`,
                             },
                             effectiveDateTime: '2021-01-09T20:00:06Z',
                             valueQuantity: {

--- a/src/router/bundle/bundleParser.test.ts
+++ b/src/router/bundle/bundleParser.test.ts
@@ -830,7 +830,7 @@ describe('parseResource', () => {
                       ],
                     },
                     "device": Object {
-                      "reference": "Device/222",
+                      "reference": "Device/222/_history/7",
                     },
                     "effectiveDateTime": "2021-01-09T20:00:06Z",
                     "resourceType": "Observation",

--- a/src/router/bundle/bundleParser.ts
+++ b/src/router/bundle/bundleParser.ts
@@ -216,18 +216,20 @@ export default class BundleParser {
                     // rootUrl as the server, we check if the server has that reference. If the server does not have the
                     // reference we throw an error
                     if (!referenceIsFound && [serverUrl, `${serverUrl}/`].includes(reference.rootUrl)) {
+                        let parsedVid = reference.vid;
+                        let vidWithHistory = false;
                         try {
-                            if (reference.vid) {
-                                let { vid } = reference;
-                                if (vid.startsWith('/_history')) {
-                                    const parts = reference.vid.split('/');
-                                    vid = parts[parts.length - 1];
+                            if (parsedVid) {
+                                if (reference.vid.startsWith('/_history')) {
+                                    const parts = parsedVid.split('/');
+                                    parsedVid = parts[parts.length - 1];
+                                    vidWithHistory = true;
                                 }
                                 // eslint-disable-next-line no-await-in-loop
                                 await dataService.vReadResource({
                                     resourceType: reference.resourceType,
                                     id: reference.id,
-                                    vid,
+                                    vid: parsedVid,
                                 });
                             } else {
                                 // eslint-disable-next-line no-await-in-loop
@@ -241,11 +243,10 @@ export default class BundleParser {
                                 `This entry refer to a resource that does not exist on this server. Entry is referring to '${reference.resourceType}/${reference.id}'`,
                             );
                         }
-                        set(
-                            requestWithRef,
-                            `resource.${reference.referencePath}`,
-                            `${reference.resourceType}/${reference.id}`,
-                        );
+                        const ref = vidWithHistory
+                            ? `${reference.resourceType}/${reference.id}/_history/${parsedVid}`
+                            : `${reference.resourceType}/${reference.id}`;
+                        set(requestWithRef, `resource.${reference.referencePath}`, ref);
                         referenceIsFound = true;
                     }
                     if (!referenceIsFound) {

--- a/src/router/bundle/bundleParser.ts
+++ b/src/router/bundle/bundleParser.ts
@@ -218,11 +218,16 @@ export default class BundleParser {
                     if (!referenceIsFound && [serverUrl, `${serverUrl}/`].includes(reference.rootUrl)) {
                         try {
                             if (reference.vid) {
+                                let { vid } = reference;
+                                if (vid.startsWith('/_history')) {
+                                    const parts = reference.vid.split('/');
+                                    vid = parts[parts.length - 1];
+                                }
                                 // eslint-disable-next-line no-await-in-loop
                                 await dataService.vReadResource({
                                     resourceType: reference.resourceType,
                                     id: reference.id,
-                                    vid: reference.vid,
+                                    vid,
                                 });
                             } else {
                                 // eslint-disable-next-line no-await-in-loop


### PR DESCRIPTION
Issue #, if available:

Description of changes:
If a bundle contains versioned references to resources already in persistent storage, the checkReferences currently sends the string `/_history/<vid>` as vid to the vReadResource. This fix removes the `/_history/` prefix.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.