### PR TITLE
fix: update FHIR v4 schema and fix the validator

### DIFF
--- a/src/router/validation/schemas/fhir.schema.v4.json
+++ b/src/router/validation/schemas/fhir.schema.v4.json
@@ -1,5 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-06/schema#",
+  "id": "http://hl7.org/fhir/json-schema/4.0",
   "description": "see http://hl7.org/fhir/json.html#schema for information about the FHIR Json Schemas. id:http://hl7.org/fhir/json-schema/4.0",
   "discriminator": {
     "propertyName": "resourceType",


### PR DESCRIPTION
Issue #, if available: [Issue-377](https://github.com/awslabs/fhir-works-on-aws-deployment/issues/377)

Description of changes: 
* Updated v4 schema from https://hl7.org/FHIR/fhir.schema.json.zip
* Fixed the validator to use `id` field if it was missing

Testing
* No new unit tests added. Existing unit tests already capture both the cases (with and without id)
* Also tested that API calls worked locally

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.