### PR TITLE
feat: Group export map additional parameters needed

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -129,7 +129,11 @@ export function generateServerlessRouter(
 
     // Export
     if (fhirConfig.profile.bulkDataAccess) {
-        const exportRoute = new ExportRoute(fhirConfig.profile.bulkDataAccess, fhirConfig.auth.authorization);
+        const exportRoute = new ExportRoute(
+            fhirConfig.profile.bulkDataAccess,
+            fhirConfig.auth.authorization,
+            fhirConfig.profile.fhirVersion,
+        );
         mainRouter.use('/', exportRoute.router);
     }
 

--- a/src/router/bundle/bundleHandler.test.ts
+++ b/src/router/bundle/bundleHandler.test.ts
@@ -54,6 +54,9 @@ const genericResource: GenericResource = {
     typeHistory: stubs.history,
     typeSearch: stubs.search,
 };
+
+const dummyServerUrl: string = 'https://dummy-server-url';
+
 const resources = {};
 
 const SUPPORTED_R4_RESOURCES = [
@@ -414,7 +417,7 @@ describe('ERROR Cases: Validation of Bundle request', () => {
         bundleRequestJSON.type = 'batch';
 
         await expect(
-            bundleHandlerR4.processBatch(bundleRequestJSON, practitionerDecoded, dummyRequestContext),
+            bundleHandlerR4.processBatch(bundleRequestJSON, practitionerDecoded, dummyRequestContext, dummyServerUrl),
         ).rejects.toThrowError(new createError.BadRequest('Currently this server only support transaction Bundles'));
     });
 
@@ -431,7 +434,12 @@ describe('ERROR Cases: Validation of Bundle request', () => {
         bundleRequestJSON.entry.push(invalidReadRequest);
 
         await expect(
-            bundleHandlerR4.processTransaction(bundleRequestJSON, practitionerDecoded, dummyRequestContext),
+            bundleHandlerR4.processTransaction(
+                bundleRequestJSON,
+                practitionerDecoded,
+                dummyRequestContext,
+                dummyServerUrl,
+            ),
         ).rejects.toThrowError(
             new InvalidResourceError(
                 'Failed to parse request body as JSON resource. Error was: data.entry[0].request should NOT have additional properties',
@@ -444,7 +452,12 @@ describe('ERROR Cases: Validation of Bundle request', () => {
         bundleRequestJSON.total = 'abc';
 
         await expect(
-            bundleHandlerSTU3.processTransaction(bundleRequestJSON, practitionerDecoded, dummyRequestContext),
+            bundleHandlerSTU3.processTransaction(
+                bundleRequestJSON,
+                practitionerDecoded,
+                dummyRequestContext,
+                dummyServerUrl,
+            ),
         ).rejects.toThrowError(
             new InvalidResourceError(
                 'Failed to parse request body as JSON resource. Error was: data.total should be number, data.total should match pattern "[0]|([1-9][0-9]*)"',
@@ -457,7 +470,12 @@ describe('ERROR Cases: Validation of Bundle request', () => {
         delete bundleRequestJSON.resourceType;
 
         await expect(
-            bundleHandlerSTU3.processTransaction(bundleRequestJSON, practitionerDecoded, dummyRequestContext),
+            bundleHandlerSTU3.processTransaction(
+                bundleRequestJSON,
+                practitionerDecoded,
+                dummyRequestContext,
+                dummyServerUrl,
+            ),
         ).rejects.toThrowError(new InvalidResourceError("resource should have required property 'resourceType'"));
     });
 
@@ -474,7 +492,12 @@ describe('ERROR Cases: Validation of Bundle request', () => {
         bundleRequestJSON.entry.push(searchRequest);
 
         await expect(
-            bundleHandlerR4.processTransaction(bundleRequestJSON, practitionerDecoded, dummyRequestContext),
+            bundleHandlerR4.processTransaction(
+                bundleRequestJSON,
+                practitionerDecoded,
+                dummyRequestContext,
+                dummyServerUrl,
+            ),
         ).rejects.toThrowError(new createError.BadRequest('We currently do not support SEARCH entries in the Bundle'));
     });
 
@@ -491,7 +514,12 @@ describe('ERROR Cases: Validation of Bundle request', () => {
         bundleRequestJSON.entry.push(vreadRequest);
 
         await expect(
-            bundleHandlerR4.processTransaction(bundleRequestJSON, practitionerDecoded, dummyRequestContext),
+            bundleHandlerR4.processTransaction(
+                bundleRequestJSON,
+                practitionerDecoded,
+                dummyRequestContext,
+                dummyServerUrl,
+            ),
         ).rejects.toThrowError(new createError.BadRequest('We currently do not support V_READ entries in the Bundle'));
     });
 
@@ -507,7 +535,12 @@ describe('ERROR Cases: Validation of Bundle request', () => {
             bundleRequestJSON.entry.push(readRequest);
         }
         await expect(
-            bundleHandlerR4.processTransaction(bundleRequestJSON, practitionerDecoded, dummyRequestContext),
+            bundleHandlerR4.processTransaction(
+                bundleRequestJSON,
+                practitionerDecoded,
+                dummyRequestContext,
+                dummyServerUrl,
+            ),
         ).rejects.toThrowError(
             new createError.BadRequest(
                 `Maximum number of entries for a Bundle is ${MAX_BUNDLE_ENTRIES}. There are currently ${bundleRequestJSON.entry.length} entries in this Bundle`,
@@ -526,6 +559,7 @@ describe('SUCCESS Cases: Testing Bundle with CRUD entries', () => {
             bundleRequestJSON,
             practitionerDecoded,
             dummyRequestContext,
+            dummyServerUrl,
         );
 
         const expectedResult = {
@@ -608,6 +642,7 @@ describe('SUCCESS Cases: Testing Bundle with CRUD entries', () => {
             bundleRequestJSON,
             practitionerDecoded,
             dummyRequestContext,
+            dummyServerUrl
         );
 
         expect(actualResult).toMatchObject({
@@ -671,6 +706,7 @@ describe('ERROR Cases: Bundle not authorized', () => {
                 bundleRequestJSON,
                 practitionerDecoded,
                 dummyRequestContext,
+                dummyServerUrl,
             ),
         ).rejects.toThrowError(new UnauthorizedError('An entry within the Bundle is not authorized'));
     });
@@ -764,6 +800,7 @@ describe('ERROR Cases: Bundle not authorized', () => {
                 bundleRequestJSON,
                 practitionerDecoded,
                 dummyRequestContext,
+                dummyServerUrl,
             ),
         ).resolves.toMatchObject(expectedResult);
     });
@@ -824,6 +861,7 @@ describe('SERVER-CAPABILITIES Cases: Validating Bundle request is allowed given 
                     bundleRequestJsonCreatePatient,
                     practitionerDecoded,
                     dummyRequestContext,
+                    dummyServerUrl,
                 ),
             ).rejects.toThrowError(
                 new createError.BadRequest('Server does not support these resource and operations: {Patient: create}'),
@@ -860,6 +898,7 @@ describe('SERVER-CAPABILITIES Cases: Validating Bundle request is allowed given 
                     bundleRequestJsonCreatePatient,
                     practitionerDecoded,
                     dummyRequestContext,
+                    dummyServerUrl,
                 ),
             ).rejects.toThrowError(
                 new createError.BadRequest('Server does not support these resource and operations: {Patient: create}'),
@@ -908,6 +947,7 @@ describe('SERVER-CAPABILITIES Cases: Validating Bundle request is allowed given 
                 bundleRequestJsonCreatePatient,
                 practitionerDecoded,
                 dummyRequestContext,
+                dummyServerUrl,
             );
 
             // CHECK
@@ -938,6 +978,7 @@ describe('SERVER-CAPABILITIES Cases: Validating Bundle request is allowed given 
                 bundleRequestJsonCreatePatient,
                 practitionerDecoded,
                 dummyRequestContext,
+                dummyServerUrl,
             );
 
             // CHECK

--- a/src/router/routes/exportRoute.ts
+++ b/src/router/routes/exportRoute.ts
@@ -35,17 +35,19 @@ export default class ExportRoute {
     }
 
     async initiateExportRequests(req: express.Request, res: express.Response, exportType: ExportType) {
-        const initiateExportRequest: InitiateExportRequest = ExportRouteHelper.buildInitiateExportRequest(
-            req,
-            res,
-            exportType,
-            this.fhirVersion,
-        );
-        initiateExportRequest.allowedResourceTypes = await this.authService.getAllowedResourceTypesForOperation({
+        const allowedResourceTypes = await this.authService.getAllowedResourceTypesForOperation({
             operation: 'read',
             userIdentity: res.locals.userIdentity,
             requestContext: res.locals.userIdentity,
         });
+        const initiateExportRequest: InitiateExportRequest = ExportRouteHelper.buildInitiateExportRequest(
+            req,
+            res,
+            exportType,
+            allowedResourceTypes,
+            this.fhirVersion,
+        );
+
         const jobId = await this.exportHandler.initiateExport(initiateExportRequest);
 
         const exportStatusUrl = `${res.locals.serverUrl}/$export/${jobId}`;

--- a/src/router/routes/exportRoute.ts
+++ b/src/router/routes/exportRoute.ts
@@ -75,7 +75,7 @@ export default class ExportRoute {
         );
 
         this.router.get('/Patient/\\$export', () => {
-            throw new createHttpError.BadRequest('We currently do not support Group export');
+            throw new createHttpError.BadRequest('We currently do not support Patient export');
         });
 
         // Export Job Status

--- a/src/router/routes/exportRouteHelper.ts
+++ b/src/router/routes/exportRouteHelper.ts
@@ -10,6 +10,7 @@ export default class ExportRouteHelper {
         req: express.Request,
         res: express.Response,
         exportType: ExportType,
+        allowedResourceTypes: string[],
         fhirVersion?: FhirVersion,
     ) {
         if (req.query._outputFormat && req.query._outputFormat !== 'ndjson') {
@@ -42,6 +43,7 @@ export default class ExportRouteHelper {
             tenantId: res.locals.tenantId,
             serverUrl: res.locals.serverUrl,
             fhirVersion,
+            allowedResourceTypes,
         };
         return initiateExportRequest;
     }

--- a/src/router/routes/exportRouteHelper.ts
+++ b/src/router/routes/exportRouteHelper.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-underscore-dangle */
 import express from 'express';
-import { ExportType, InitiateExportRequest } from 'fhir-works-on-aws-interface';
+import { ExportType, FhirVersion, InitiateExportRequest } from 'fhir-works-on-aws-interface';
 import createHttpError from 'http-errors';
 import isString from 'lodash/isString';
 import { dateTimeWithTimeZoneRegExp } from '../../regExpressions';
@@ -10,7 +10,7 @@ export default class ExportRouteHelper {
         req: express.Request,
         res: express.Response,
         exportType: ExportType,
-        fhirVersion?: string,
+        fhirVersion?: FhirVersion,
     ) {
         if (req.query._outputFormat && req.query._outputFormat !== 'ndjson') {
             throw new createHttpError.BadRequest('We only support exporting resources into ndjson formatted file');

--- a/src/router/routes/exportRouteHelper.ts
+++ b/src/router/routes/exportRouteHelper.ts
@@ -6,7 +6,12 @@ import isString from 'lodash/isString';
 import { dateTimeWithTimeZoneRegExp } from '../../regExpressions';
 
 export default class ExportRouteHelper {
-    static buildInitiateExportRequest(req: express.Request, res: express.Response, exportType: ExportType) {
+    static buildInitiateExportRequest(
+        req: express.Request,
+        res: express.Response,
+        exportType: ExportType,
+        fhirVersion?: string,
+    ) {
         if (req.query._outputFormat && req.query._outputFormat !== 'ndjson') {
             throw new createHttpError.BadRequest('We only support exporting resources into ndjson formatted file');
         }
@@ -35,6 +40,8 @@ export default class ExportRouteHelper {
             type: isString(req.query._type) ? req.query._type : undefined,
             groupId: isString(req.params.id) ? req.params.id : undefined,
             tenantId: res.locals.tenantId,
+            serverUrl: res.locals.serverUrl,
+            fhirVersion,
         };
         return initiateExportRequest;
     }


### PR DESCRIPTION
Issue #, if available:

Description of changes:

* Map additional parameters needed by group export
* allowedResourceTypes for filtering down the resource types
* serverUrl for validating if url reference points to resource on the same server
* fhirVersion for getting patientCompartment definition in the specific fhir version
* Depends on https://github.com/awslabs/fhir-works-on-aws-interface/pull/73 
* Map allowed resource types
* Fix broken unit tests 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.