### PR TITLE
fix: fix invalid capability statement

### DIFF
--- a/src/router/metadata/cap.rest.security.template.ts
+++ b/src/router/metadata/cap.rest.security.template.ts
@@ -13,7 +13,7 @@ export default function makeSecurity(authConfig: Auth, hasCORSEnabled: boolean =
                 {
                     coding: [
                         {
-                            system: 'http://hl7.org/fhir/ValueSet/restful-security-service',
+                            system: 'http://terminology.hl7.org/CodeSystem/restful-security-service',
                             code: authConfig.strategy.service,
                         },
                     ],

--- a/src/router/metadata/cap.rest.template.ts
+++ b/src/router/metadata/cap.rest.template.ts
@@ -33,13 +33,9 @@ export default function makeRest(
         rest.operation = [
             {
                 name: 'export',
-                definition:
-                    'This FHIR Operation initiates the asynchronous generation of data to which the client is authorized. Currently only system level export is supported. For more information please refer here: http://hl7.org/fhir/uv/bulkdata/export/index.html#bulk-data-kick-off-request',
-            },
-            {
-                name: 'export-poll-status',
-                definition:
-                    'After a bulk data request has been started, the client MAY poll the status URL provided in the Content-Location header. For more details please refer here: http://hl7.org/fhir/uv/bulkdata/export/index.html#bulk-data-status-request',
+                definition: 'http://hl7.org/fhir/uv/bulkdata/OperationDefinition/export',
+                documentation:
+                    'This FHIR Operation initiates the asynchronous generation of data to which the client is authorized. Currently only system level export is supported. For more information please refer here: http://hl7.org/fhir/uv/bulkdata/export/index.html#bulk-data-kick-off-request. After a bulk data request has been started, the client MAY poll the status URL provided in the Content-Location header. For more details please refer here: http://hl7.org/fhir/uv/bulkdata/export/index.html#bulk-data-status-request',
             },
         ];
     }

--- a/src/router/metadata/metadataHandler.test.ts
+++ b/src/router/metadata/metadataHandler.test.ts
@@ -599,13 +599,9 @@ test('R4: FHIR Config V4 with bulkDataAccess', async () => {
     expect(response.resource.rest[0].operation).toEqual([
         {
             name: 'export',
-            definition:
-                'This FHIR Operation initiates the asynchronous generation of data to which the client is authorized. Currently only system level export is supported. For more information please refer here: http://hl7.org/fhir/uv/bulkdata/export/index.html#bulk-data-kick-off-request',
-        },
-        {
-            name: 'export-poll-status',
-            definition:
-                'After a bulk data request has been started, the client MAY poll the status URL provided in the Content-Location header. For more details please refer here: http://hl7.org/fhir/uv/bulkdata/export/index.html#bulk-data-status-request',
+            definition: 'http://hl7.org/fhir/uv/bulkdata/OperationDefinition/export',
+            documentation:
+                'This FHIR Operation initiates the asynchronous generation of data to which the client is authorized. Currently only system level export is supported. For more information please refer here: http://hl7.org/fhir/uv/bulkdata/export/index.html#bulk-data-kick-off-request. After a bulk data request has been started, the client MAY poll the status URL provided in the Content-Location header. For more details please refer here: http://hl7.org/fhir/uv/bulkdata/export/index.html#bulk-data-status-request',
         },
     ]);
 });
@@ -674,7 +670,7 @@ test('R4: FHIR Config V4 with all Oauth Policy endpoints', async () => {
                 coding: [
                     {
                         code: 'OAuth',
-                        system: 'http://hl7.org/fhir/ValueSet/restful-security-service',
+                        system: 'http://terminology.hl7.org/CodeSystem/restful-security-service',
                     },
                 ],
             },
@@ -723,7 +719,7 @@ test('R4: FHIR Config V4 with some Oauth Policy endpoints', async () => {
                 coding: [
                     {
                         code: 'OAuth',
-                        system: 'http://hl7.org/fhir/ValueSet/restful-security-service',
+                        system: 'http://terminology.hl7.org/CodeSystem/restful-security-service',
                     },
                 ],
             },


### PR DESCRIPTION
Fixes part of https://github.com/awslabs/fhir-works-on-aws-routing/issues/106

Note that `export-poll-status` was never a real operation per the FHIR spec. The `export` operation does both things(initiate export requests, and get the status/results of previous export jobs)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.