### PR TITLE
fix: updated exportRouteHelper tests

### DIFF
--- a/src/router/routes/exportRouteHelper.test.ts
+++ b/src/router/routes/exportRouteHelper.test.ts
@@ -11,6 +11,7 @@ describe('buildInitiateExportRequest', () => {
         locals: {
             userIdentity: { sub: 'abcd-1234' },
             requestContext: { verb: 'GET', hostname: 'test.acme.com' },
+            serverUrl: 'http://test.acme.com',
         },
     });
 
@@ -40,6 +41,7 @@ describe('buildInitiateExportRequest', () => {
             outputFormat: 'ndjson',
             since: '2020-09-01T00:00:00.000Z',
             type: 'Patient',
+            serverUrl: 'http://test.acme.com',
             allowedResourceTypes: mockedAllowedResourceTypes,
             fhirVersion: r4Version,
         });
@@ -72,6 +74,7 @@ describe('buildInitiateExportRequest', () => {
             since: '2020-09-01T00:00:00.000Z',
             type: 'Patient',
             groupId: '1',
+            serverUrl: 'http://test.acme.com',
             allowedResourceTypes: mockedAllowedResourceTypes,
             fhirVersion: r4Version,
         });
@@ -98,6 +101,7 @@ describe('buildInitiateExportRequest', () => {
             since: undefined,
             type: undefined,
             groupId: '1',
+            serverUrl: 'http://test.acme.com',
             allowedResourceTypes: mockedAllowedResourceTypes,
             fhirVersion: r4Version,
         });

--- a/src/router/routes/exportRouteHelper.test.ts
+++ b/src/router/routes/exportRouteHelper.test.ts
@@ -1,9 +1,12 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { mockRequest, mockResponse } from 'mock-req-res';
+import { FhirVersion, BASE_R4_RESOURCES } from 'fhir-works-on-aws-interface';
 import ExportRouteHelper from './exportRouteHelper';
 import { utcTimeRegExp } from '../../regExpressions';
 
 describe('buildInitiateExportRequest', () => {
+    const r4Version: FhirVersion = '4.0.1';
+    const mockedAllowedResourceTypes = BASE_R4_RESOURCES;
     const mockedResponse = mockResponse({
         locals: {
             userIdentity: { sub: 'abcd-1234' },
@@ -23,7 +26,13 @@ describe('buildInitiateExportRequest', () => {
             },
         });
 
-        const actualInitiateExportRequest = ExportRouteHelper.buildInitiateExportRequest(req, mockedResponse, 'system');
+        const actualInitiateExportRequest = ExportRouteHelper.buildInitiateExportRequest(
+            req,
+            mockedResponse,
+            'system',
+            mockedAllowedResourceTypes,
+            r4Version,
+        );
         expect(actualInitiateExportRequest).toMatchObject({
             requesterUserId: 'abcd-1234',
             transactionTime: expect.stringMatching(utcTimeRegExp),
@@ -31,6 +40,8 @@ describe('buildInitiateExportRequest', () => {
             outputFormat: 'ndjson',
             since: '2020-09-01T00:00:00.000Z',
             type: 'Patient',
+            allowedResourceTypes: mockedAllowedResourceTypes,
+            fhirVersion: r4Version,
         });
     });
 
@@ -46,7 +57,13 @@ describe('buildInitiateExportRequest', () => {
             },
         });
 
-        const actualInitiateExportRequest = ExportRouteHelper.buildInitiateExportRequest(req, mockedResponse, 'group');
+        const actualInitiateExportRequest = ExportRouteHelper.buildInitiateExportRequest(
+            req,
+            mockedResponse,
+            'group',
+            mockedAllowedResourceTypes,
+            r4Version,
+        );
         expect(actualInitiateExportRequest).toMatchObject({
             requesterUserId: 'abcd-1234',
             transactionTime: expect.stringMatching(utcTimeRegExp),
@@ -55,6 +72,8 @@ describe('buildInitiateExportRequest', () => {
             since: '2020-09-01T00:00:00.000Z',
             type: 'Patient',
             groupId: '1',
+            allowedResourceTypes: mockedAllowedResourceTypes,
+            fhirVersion: r4Version,
         });
     });
 
@@ -65,7 +84,13 @@ describe('buildInitiateExportRequest', () => {
             },
         });
 
-        const actualInitiateExportRequest = ExportRouteHelper.buildInitiateExportRequest(req, mockedResponse, 'group');
+        const actualInitiateExportRequest = ExportRouteHelper.buildInitiateExportRequest(
+            req,
+            mockedResponse,
+            'group',
+            mockedAllowedResourceTypes,
+            r4Version,
+        );
         expect(actualInitiateExportRequest).toMatchObject({
             requesterUserId: 'abcd-1234',
             exportType: 'group',
@@ -73,6 +98,8 @@ describe('buildInitiateExportRequest', () => {
             since: undefined,
             type: undefined,
             groupId: '1',
+            allowedResourceTypes: mockedAllowedResourceTypes,
+            fhirVersion: r4Version,
         });
     });
 
@@ -88,7 +115,13 @@ describe('buildInitiateExportRequest', () => {
         });
 
         try {
-            ExportRouteHelper.buildInitiateExportRequest(req, mockedResponse, 'group');
+            ExportRouteHelper.buildInitiateExportRequest(
+                req,
+                mockedResponse,
+                'group',
+                mockedAllowedResourceTypes,
+                r4Version,
+            );
         } catch (e) {
             expect(e.name).toEqual('BadRequestError');
             expect(e.message).toEqual('We only support exporting resources into ndjson formatted file');
@@ -106,7 +139,13 @@ describe('buildInitiateExportRequest', () => {
         });
 
         try {
-            ExportRouteHelper.buildInitiateExportRequest(req, mockedResponse, 'group');
+            ExportRouteHelper.buildInitiateExportRequest(
+                req,
+                mockedResponse,
+                'group',
+                mockedAllowedResourceTypes,
+                r4Version,
+            );
         } catch (e) {
             expect(e.name).toEqual('BadRequestError');
             expect(e.message).toEqual(


### PR DESCRIPTION
fix: updated exportRouteHelper tests to include additional group export parameters

Issue #, if available:

Description of changes:
The buildInitiateExportRequest methods expects allowedResourceTypes as a parameter. Updated existing tests to included allowedResourceTypes and the optional parameter fhirVersion

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.