### PR TITLE
fix: properly emit throttle error

### DIFF
--- a/src/router/routes/errorHandling.ts
+++ b/src/router/routes/errorHandling.ts
@@ -57,6 +57,7 @@ const statusToOutcome: Record<number, { severity: IssueSeverity; code: IssueCode
     403: { severity: 'error', code: 'security' },
     404: { severity: 'error', code: 'not-found' },
     409: { severity: 'error', code: 'conflict' },
+    429: { severity: 'error', code: 'throttled' },
     500: { severity: 'error', code: 'exception' },
 };
 


### PR DESCRIPTION
When a 429 occurs emit 'throttling' instead of 'processing'


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.