### PR TITLE
feat: add group export operation to capability statement

### DIFF
--- a/src/router/metadata/cap.rest.template.ts
+++ b/src/router/metadata/cap.rest.template.ts
@@ -35,7 +35,13 @@ export default function makeRest(
                 name: 'export',
                 definition: 'http://hl7.org/fhir/uv/bulkdata/OperationDefinition/export',
                 documentation:
-                    'This FHIR Operation initiates the asynchronous generation of data to which the client is authorized. Currently only system level export is supported. For more information please refer here: http://hl7.org/fhir/uv/bulkdata/export/index.html#bulk-data-kick-off-request. After a bulk data request has been started, the client MAY poll the status URL provided in the Content-Location header. For more details please refer here: http://hl7.org/fhir/uv/bulkdata/export/index.html#bulk-data-status-request',
+                    'This FHIR Operation initiates the asynchronous generation of data to which the client is authorized. For more information please refer here: http://hl7.org/fhir/uv/bulkdata/export/index.html#bulk-data-kick-off-request. After a bulk data request has been started, the client MAY poll the status URL provided in the Content-Location header. For more details please refer here: http://hl7.org/fhir/uv/bulkdata/export/index.html#bulk-data-status-request',
+            },
+            {
+                name: 'group-export',
+                definition: 'http://hl7.org/fhir/uv/bulkdata/OperationDefinition/group-export',
+                documentation:
+                    'This FHIR Operation initiates the asynchronous generation of data for a given Group. For more information please refer here: http://hl7.org/fhir/uv/bulkdata/export/index.html#endpoint---group-of-patients. After a bulk data request has been started, the client MAY poll the status URL provided in the Content-Location header. For more details please refer here: http://hl7.org/fhir/uv/bulkdata/export/index.html#bulk-data-status-request',
             },
         ];
     }

--- a/src/router/metadata/metadataHandler.test.ts
+++ b/src/router/metadata/metadataHandler.test.ts
@@ -596,14 +596,20 @@ test('R4: FHIR Config V4 with bulkDataAccess', async () => {
     const metadataHandler: MetadataHandler = new MetadataHandler(configHandler, registry, operationRegistryMock);
     const response = await metadataHandler.capabilities({ fhirVersion: '4.0.1', mode: 'full' });
 
-    expect(response.resource.rest[0].operation).toEqual([
-        {
-            name: 'export',
-            definition: 'http://hl7.org/fhir/uv/bulkdata/OperationDefinition/export',
-            documentation:
-                'This FHIR Operation initiates the asynchronous generation of data to which the client is authorized. Currently only system level export is supported. For more information please refer here: http://hl7.org/fhir/uv/bulkdata/export/index.html#bulk-data-kick-off-request. After a bulk data request has been started, the client MAY poll the status URL provided in the Content-Location header. For more details please refer here: http://hl7.org/fhir/uv/bulkdata/export/index.html#bulk-data-status-request',
-        },
-    ]);
+    expect(response.resource.rest[0].operation).toMatchInlineSnapshot(`
+        Array [
+          Object {
+            "definition": "http://hl7.org/fhir/uv/bulkdata/OperationDefinition/export",
+            "documentation": "This FHIR Operation initiates the asynchronous generation of data to which the client is authorized. For more information please refer here: http://hl7.org/fhir/uv/bulkdata/export/index.html#bulk-data-kick-off-request. After a bulk data request has been started, the client MAY poll the status URL provided in the Content-Location header. For more details please refer here: http://hl7.org/fhir/uv/bulkdata/export/index.html#bulk-data-status-request",
+            "name": "export",
+          },
+          Object {
+            "definition": "http://hl7.org/fhir/uv/bulkdata/OperationDefinition/group-export",
+            "documentation": "This FHIR Operation initiates the asynchronous generation of data for a given Group. For more information please refer here: http://hl7.org/fhir/uv/bulkdata/export/index.html#endpoint---group-of-patients. After a bulk data request has been started, the client MAY poll the status URL provided in the Content-Location header. For more details please refer here: http://hl7.org/fhir/uv/bulkdata/export/index.html#bulk-data-status-request",
+            "name": "group-export",
+          },
+        ]
+    `);
 });
 
 test('R4: FHIR Config V4 without bulkDataAccess', async () => {


### PR DESCRIPTION
The newly released Group export was missing from the cap statement

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.