### PR TITLE
fix: move group export operation under Group resource

### DIFF
--- a/src/router/metadata/cap.rest.template.ts
+++ b/src/router/metadata/cap.rest.template.ts
@@ -37,13 +37,19 @@ export default function makeRest(
                 documentation:
                     'This FHIR Operation initiates the asynchronous generation of data to which the client is authorized. For more information please refer here: http://hl7.org/fhir/uv/bulkdata/export/index.html#bulk-data-kick-off-request. After a bulk data request has been started, the client MAY poll the status URL provided in the Content-Location header. For more details please refer here: http://hl7.org/fhir/uv/bulkdata/export/index.html#bulk-data-status-request',
             },
-            {
+        ];
+
+        const groupResource = rest.resource.find((r: any) => r.type === 'Group');
+
+        if (groupResource !== undefined) {
+            groupResource.operation = groupResource.operation ?? [];
+            groupResource.operation.push({
                 name: 'group-export',
                 definition: 'http://hl7.org/fhir/uv/bulkdata/OperationDefinition/group-export',
                 documentation:
                     'This FHIR Operation initiates the asynchronous generation of data for a given Group. For more information please refer here: http://hl7.org/fhir/uv/bulkdata/export/index.html#endpoint---group-of-patients. After a bulk data request has been started, the client MAY poll the status URL provided in the Content-Location header. For more details please refer here: http://hl7.org/fhir/uv/bulkdata/export/index.html#bulk-data-status-request',
-            },
-        ];
+            });
+        }
     }
     return rest;
 }

--- a/src/router/metadata/metadataHandler.test.ts
+++ b/src/router/metadata/metadataHandler.test.ts
@@ -603,6 +603,10 @@ test('R4: FHIR Config V4 with bulkDataAccess', async () => {
             "documentation": "This FHIR Operation initiates the asynchronous generation of data to which the client is authorized. For more information please refer here: http://hl7.org/fhir/uv/bulkdata/export/index.html#bulk-data-kick-off-request. After a bulk data request has been started, the client MAY poll the status URL provided in the Content-Location header. For more details please refer here: http://hl7.org/fhir/uv/bulkdata/export/index.html#bulk-data-status-request",
             "name": "export",
           },
+        ]
+    `);
+    expect(response.resource.rest[0].resource.find((r: any) => r.type === 'Group')?.operation).toMatchInlineSnapshot(`
+        Array [
           Object {
             "definition": "http://hl7.org/fhir/uv/bulkdata/OperationDefinition/group-export",
             "documentation": "This FHIR Operation initiates the asynchronous generation of data for a given Group. For more information please refer here: http://hl7.org/fhir/uv/bulkdata/export/index.html#endpoint---group-of-patients. After a bulk data request has been started, the client MAY poll the status URL provided in the Content-Location header. For more details please refer here: http://hl7.org/fhir/uv/bulkdata/export/index.html#bulk-data-status-request",
@@ -618,6 +622,7 @@ test('R4: FHIR Config V4 without bulkDataAccess', async () => {
     const response = await metadataHandler.capabilities({ fhirVersion: '4.0.1', mode: 'full' });
 
     expect(response.resource.rest[0].operation).toBeUndefined();
+    expect(response.resource.rest[0].resource.find((r: any) => r.type === 'Group')?.operation).toBeUndefined();
 });
 
 test('R4: FHIR Config V4 with all Oauth Policy endpoints', async () => {


### PR DESCRIPTION
Group export should be under the Group resource and not at the top "rest" level.

This is consistent with the Inferno tests expectation: https://inferno.healthit.gov/bulk-data-server/eyJlcnIiOiIiLCJwYWdlIjoxMDAwMCwiZHVyIjoxMCwidGx0IjoxNSwibSI6MSwic3R1Ijo0fQ/fhir/metadata

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.