### PR TITLE
feat: use requiresAccessToken value from GetExportStatusResponse

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "cors": "^2.8.5",
     "errorhandler": "^1.5.1",
     "express": "^4.17.1",
-    "fhir-works-on-aws-interface": "^11.1.0",
+    "fhir-works-on-aws-interface": "^11.2.0",
     "flat": "^5.0.0",
     "http-errors": "^1.8.0",
     "lodash": "^4.17.15",

--- a/src/router/routes/exportRoute.ts
+++ b/src/router/routes/exportRoute.ts
@@ -103,7 +103,7 @@ export default class ExportRoute {
                             queryParams,
                             groupId,
                         ),
-                        requiresAccessToken: false,
+                        requiresAccessToken: response.requiresAccessToken,
                         output: response.exportedFileUrls,
                         error: response.errorArray,
                     };

--- a/yarn.lock
+++ b/yarn.lock
@@ -2336,10 +2336,10 @@ fecha@^4.2.0:
   resolved "https://registry.yarnpkg.com/fecha/-/fecha-4.2.1.tgz#0a83ad8f86ef62a091e22bb5a039cd03d23eecce"
   integrity sha512-MMMQ0ludy/nBs1/o0zVOiKTpG7qMbonKUzjJgQFEuvq6INZ1OraKPRAWkBq5vlKLOUMpmNYG1JoN3oDPUQ9m3Q==
 
-fhir-works-on-aws-interface@^11.1.0:
-  version "11.1.0"
-  resolved "https://registry.yarnpkg.com/fhir-works-on-aws-interface/-/fhir-works-on-aws-interface-11.1.0.tgz#5950cb0538f831b6b2b34a0c83ab411c5a4e521c"
-  integrity sha512-wqLc3AFX8NwHQl5Ps406ozwz5LqXqKzXynicHbmsM8e29Hsb8tGS8+p2sXvhG9y+/DBj7QJljcJYN69F0eBt0g==
+fhir-works-on-aws-interface@^11.2.0:
+  version "11.2.0"
+  resolved "https://registry.yarnpkg.com/fhir-works-on-aws-interface/-/fhir-works-on-aws-interface-11.2.0.tgz#2e12b3406ace4e24df8a18a827c50b834b633339"
+  integrity sha512-in2KVLKNfHPmJBwDNZrnJKg6VUrLncgBeL5Ow6ZE0tLxILBzZLNK7KWfcPlH3l6jQ4N9HLcF/GrOAGsGUGjHyQ==
   dependencies:
     winston "^3.3.3"
     winston-transport "^4.4.0"


### PR DESCRIPTION
We are adding flexibility to how the export results URLs are generated and we need requiresAccessToken to be dynamic.
Currently the requiresAccessToken field is hard-coded to false in the router response.

Related PRs:
- https://github.com/awslabs/fhir-works-on-aws-interface/pull/85

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.