### PR TITLE
feat: pass sessionId param to search

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "cors": "^2.8.5",
     "errorhandler": "^1.5.1",
     "express": "^4.17.1",
-    "fhir-works-on-aws-interface": "^11.2.0",
+    "fhir-works-on-aws-interface": "^11.3.0",
     "flat": "^5.0.0",
     "http-errors": "^1.8.0",
     "lodash": "^4.17.15",

--- a/src/router/handlers/resourceHandler.test.ts
+++ b/src/router/handlers/resourceHandler.test.ts
@@ -419,6 +419,7 @@ describe('Testing search', () => {
             },
             resourceType: 'Patient',
             searchFilters: [],
+            sessionId: '99914b932bd37a50b983c5e7c90ae93b', // hash of user identity
         });
         expect(searchResponse.resourceType).toEqual('Bundle');
         expect(searchResponse.meta).toBeDefined();

--- a/src/router/handlers/resourceHandler.test.ts
+++ b/src/router/handlers/resourceHandler.test.ts
@@ -419,7 +419,7 @@ describe('Testing search', () => {
             },
             resourceType: 'Patient',
             searchFilters: [],
-            sessionId: '99914b932bd37a50b983c5e7c90ae93b', // hash of user identity
+            sessionId: '44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a', // hash of user identity
         });
         expect(searchResponse.resourceType).toEqual('Bundle');
         expect(searchResponse.meta).toBeDefined();

--- a/src/router/handlers/resourceHandler.ts
+++ b/src/router/handlers/resourceHandler.ts
@@ -12,13 +12,11 @@ import {
     Validator,
     RequestContext,
 } from 'fhir-works-on-aws-interface';
-import { createHash } from 'crypto';
 import BundleGenerator from '../bundle/bundleGenerator';
 import CrudHandlerInterface from './CrudHandlerInterface';
 import OperationsGenerator from '../operationsGenerator';
 import { validateResource } from '../validation/validationUtilities';
-
-const hash = (o: any): string => createHash('md5').update(JSON.stringify(o)).digest('hex');
+import { hash } from './utils';
 
 export default class ResourceHandler implements CrudHandlerInterface {
     private validators: Validator[];

--- a/src/router/handlers/resourceHandler.ts
+++ b/src/router/handlers/resourceHandler.ts
@@ -12,10 +12,13 @@ import {
     Validator,
     RequestContext,
 } from 'fhir-works-on-aws-interface';
+import { createHash } from 'crypto';
 import BundleGenerator from '../bundle/bundleGenerator';
 import CrudHandlerInterface from './CrudHandlerInterface';
 import OperationsGenerator from '../operationsGenerator';
 import { validateResource } from '../validation/validationUtilities';
+
+const hash = (o: any): string => createHash('md5').update(JSON.stringify(o)).digest('hex');
 
 export default class ResourceHandler implements CrudHandlerInterface {
     private validators: Validator[];
@@ -93,6 +96,7 @@ export default class ResourceHandler implements CrudHandlerInterface {
             allowedResourceTypes,
             searchFilters,
             tenantId,
+            sessionId: hash(userIdentity),
         });
         const bundle = BundleGenerator.generateBundle(
             serverUrl,

--- a/src/router/handlers/rootHandler.ts
+++ b/src/router/handlers/rootHandler.ts
@@ -5,6 +5,7 @@
 
 import { Search, History, KeyValueMap, Authorization, RequestContext } from 'fhir-works-on-aws-interface';
 import BundleGenerator from '../bundle/bundleGenerator';
+import { hash } from './utils';
 
 export default class RootHandler {
     private searchService: Search;
@@ -40,6 +41,7 @@ export default class RootHandler {
             baseUrl: this.serverUrl,
             searchFilters,
             tenantId,
+            sessionId: hash(userIdentity),
         });
         return BundleGenerator.generateBundle(this.serverUrl, queryParams, searchResponse.result, 'searchset');
     }

--- a/src/router/handlers/utils.ts
+++ b/src/router/handlers/utils.ts
@@ -1,0 +1,9 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+import { createHash } from 'crypto';
+
+export const hash = (o: any): string => createHash('md5').update(JSON.stringify(o)).digest('hex');

--- a/src/router/handlers/utils.ts
+++ b/src/router/handlers/utils.ts
@@ -6,4 +6,4 @@
 
 import { createHash } from 'crypto';
 
-export const hash = (o: any): string => createHash('md5').update(JSON.stringify(o)).digest('hex');
+export const hash = (o: any): string => createHash('sha256').update(JSON.stringify(o)).digest('hex');

--- a/yarn.lock
+++ b/yarn.lock
@@ -2336,10 +2336,10 @@ fecha@^4.2.0:
   resolved "https://registry.yarnpkg.com/fecha/-/fecha-4.2.1.tgz#0a83ad8f86ef62a091e22bb5a039cd03d23eecce"
   integrity sha512-MMMQ0ludy/nBs1/o0zVOiKTpG7qMbonKUzjJgQFEuvq6INZ1OraKPRAWkBq5vlKLOUMpmNYG1JoN3oDPUQ9m3Q==
 
-fhir-works-on-aws-interface@^11.2.0:
-  version "11.2.0"
-  resolved "https://registry.yarnpkg.com/fhir-works-on-aws-interface/-/fhir-works-on-aws-interface-11.2.0.tgz#2e12b3406ace4e24df8a18a827c50b834b633339"
-  integrity sha512-in2KVLKNfHPmJBwDNZrnJKg6VUrLncgBeL5Ow6ZE0tLxILBzZLNK7KWfcPlH3l6jQ4N9HLcF/GrOAGsGUGjHyQ==
+fhir-works-on-aws-interface@^11.3.0:
+  version "11.3.0"
+  resolved "https://registry.yarnpkg.com/fhir-works-on-aws-interface/-/fhir-works-on-aws-interface-11.3.0.tgz#2a02162ee19cfb188d564d37925ead98aef10915"
+  integrity sha512-d3QtB0HsjRsDbFZm6IxH0s9nZpndWej01rnJKpXg7RFjepPDRztu+bNo/Me3hwxVexiCgOIVLxXs4DqAPRHEKA==
   dependencies:
     winston "^3.3.3"
     winston-transport "^4.4.0"


### PR DESCRIPTION
Issue #, if available: https://github.com/awslabs/fhir-works-on-aws-search-es/issues/128

Pass a `sessionId` to Search to be used as the [Elasticsearch preference parameter](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-search.html#search-preference) to fix the "bouncing results" issue

A hash of the `userIdentity` is used as `sessionId`. `userIdentity` has all the claims of the JWT token.

~**NOTE:** build fails until the interface change is released and bumped here.~

Related PR:
- https://github.com/awslabs/fhir-works-on-aws-interface/pull/87
- https://github.com/awslabs/fhir-works-on-aws-search-es/pull/130

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.