### PR TITLE
perf: Compile json validation schema at init instead of in the first call

### DIFF
--- a/src/router/validation/jsonSchemaValidator.ts
+++ b/src/router/validation/jsonSchemaValidator.ts
@@ -23,11 +23,11 @@ export default class JsonSchemaValidator implements Validator {
         let schema;
         if (fhirVersion === '4.0.1') {
             ajv.addMetaSchema(schemaDraft06);
-            ajv.addSchema(fhirV4Schema);
+            ajv.compile(fhirV4Schema);
             schema = fhirV4Schema;
         } else if (fhirVersion === '3.0.1') {
             ajv.addMetaSchema(schemaDraft04);
-            ajv.addSchema(fhirV3Schema);
+            ajv.compile(fhirV3Schema);
             schema = fhirV3Schema;
         }
         this.schemaId = schema && 'id' in schema ? schema.id : '';


### PR DESCRIPTION
When using the default JsonSchemaValidator to validate incoming POST and PUT calls, it was noticed that the first call would take longer than the subsequent ones (even with lambda provisioned concurrency).

This happens because the AJV library compiles the schema on the first validate if not compiled before.



**Description of changes:**
`COMPILE_SCHEMA` environment variable is added that when set to a value of `true`, compiles the Schema on the constructor.

Running the tests can easily prove the behavior:

- COMPILE_SCHEMA not set or different than `true`

![Screenshot 2021-11-26 at 15 20 41](https://user-images.githubusercontent.com/3985504/143602910-a440fbbb-4cd4-4120-a2ea-829ea4582c6e.png)

- COMPILE_SCHEMA set to `true`

![Screenshot 2021-11-26 at 15 20 26](https://user-images.githubusercontent.com/3985504/143602970-287a3d55-e725-4562-863e-9b713b2c0eaf.png)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.