### PR TITLE
fix: Use application/fhir+json as default content-type

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "prettier": "^2.4.1",
     "sinon": "^9.0.3",
     "standard-version": "^9.3.2",
+    "supertest": "^6.1.6",
     "ts-jest": "^26.4.4",
     "typescript": "^4.1.3"
   },

--- a/src/app.test.ts
+++ b/src/app.test.ts
@@ -1,0 +1,35 @@
+import express from 'express';
+import { generateServerlessRouter } from './app';
+import r4FhirConfigNoGeneric from '../sampleData/r4FhirConfigGeneric';
+
+const request = require('supertest');
+
+describe('generateServerlessRouter', () => {
+    const fhirConfig = r4FhirConfigNoGeneric();
+    const app = generateServerlessRouter(fhirConfig, ['Patient']);
+    const requestWithSupertest = request(app);
+
+    test('Get request should return application/fhir+json', async () => {
+        app.get('/test', async (req: express.Request, res: express.Response) => {
+            res.send({ data: 'test' });
+        });
+        const res = await requestWithSupertest.get('/test');
+        expect(res.headers['content-type']).toEqual('application/fhir+json; charset=utf-8');
+    });
+
+    test('Post request should return application/fhir+json', async () => {
+        app.post('/test', async (req: express.Request, res: express.Response) => {
+            res.send({ data: 'test' });
+        });
+        const res = await requestWithSupertest.post('/test', {});
+        expect(res.headers['content-type']).toEqual('application/fhir+json; charset=utf-8');
+    });
+
+    test('Post request should return application/json if user sent application/json', async () => {
+        app.post('/test', async (req: express.Request, res: express.Response) => {
+            res.send({ data: 'test' });
+        });
+        const res = await requestWithSupertest.post('/test', {}).set('Content-Type', 'application/json');
+        expect(res.headers['content-type']).toEqual('application/json; charset=utf-8');
+    });
+});

--- a/src/app.ts
+++ b/src/app.ts
@@ -83,6 +83,18 @@ export function generateServerlessRouter(
 
     mainRouter.use(setServerUrlMiddleware(fhirConfig));
 
+    // Set default content-type to 'application/fhir+json'
+    mainRouter.use(async (req: express.Request, res: express.Response, next: express.NextFunction) => {
+        try {
+            res.contentType(
+                req.headers['content-type'] === 'application/json' ? 'application/json' : 'application/fhir+json',
+            );
+            next();
+        } catch (e) {
+            next(e);
+        }
+    });
+
     // Metadata
     const metadataRoute: MetadataRoute = new MetadataRoute(
         fhirVersion,

--- a/src/app.ts
+++ b/src/app.ts
@@ -27,6 +27,7 @@ import { FHIRStructureDefinitionRegistry } from './registry';
 import { initializeOperationRegistry } from './operationDefinitions';
 import { setServerUrlMiddleware } from './router/middlewares/setServerUrl';
 import { setTenantIdMiddleware } from './router/middlewares/setTenantId';
+import {setContentTypeMiddleware} from "./router/middlewares/setContentType";
 
 const configVersionSupported: ConfigVersion = 1;
 
@@ -82,18 +83,7 @@ export function generateServerlessRouter(
     }
 
     mainRouter.use(setServerUrlMiddleware(fhirConfig));
-
-    // Set default content-type to 'application/fhir+json'
-    mainRouter.use(async (req: express.Request, res: express.Response, next: express.NextFunction) => {
-        try {
-            res.contentType(
-                req.headers['content-type'] === 'application/json' ? 'application/json' : 'application/fhir+json',
-            );
-            next();
-        } catch (e) {
-            next(e);
-        }
-    });
+    mainRouter.use(setContentTypeMiddleware);
 
     // Metadata
     const metadataRoute: MetadataRoute = new MetadataRoute(

--- a/src/app.ts
+++ b/src/app.ts
@@ -27,7 +27,7 @@ import { FHIRStructureDefinitionRegistry } from './registry';
 import { initializeOperationRegistry } from './operationDefinitions';
 import { setServerUrlMiddleware } from './router/middlewares/setServerUrl';
 import { setTenantIdMiddleware } from './router/middlewares/setTenantId';
-import {setContentTypeMiddleware} from "./router/middlewares/setContentType";
+import { setContentTypeMiddleware } from './router/middlewares/setContentType';
 
 const configVersionSupported: ConfigVersion = 1;
 

--- a/src/router/middlewares/setContentType.test.ts
+++ b/src/router/middlewares/setContentType.test.ts
@@ -1,0 +1,51 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+import express from 'express';
+import { setContentTypeMiddleware } from './setContentType';
+
+async function sleep(milliseconds: number) {
+    return new Promise((resolve) => setTimeout(resolve, milliseconds));
+}
+
+describe('setContentTypeMiddleware', () => {
+    test('Request should return application/fhir+json by default', async () => {
+        const nextMock = jest.fn();
+        const req = { headers: {} } as unknown as express.Request;
+        const contentType = jest.fn();
+        const res = {
+            contentType,
+        } as unknown as express.Response;
+
+        setContentTypeMiddleware(req, res, nextMock);
+        await sleep(1);
+
+        expect(nextMock).toHaveBeenCalledTimes(1);
+        expect(nextMock).toHaveBeenCalledWith();
+        expect(contentType).toHaveBeenCalledWith('application/fhir+json');
+    });
+
+    test('request should return application/json if user sent application/json', async () => {
+        const nextMock = jest.fn();
+        const req = {
+            headers: {
+                'content-type': 'application/json',
+            },
+        } as unknown as express.Request;
+        const contentType = jest.fn();
+        const res = {
+            contentType,
+        } as unknown as express.Response;
+
+        setContentTypeMiddleware(req, res, nextMock);
+        await sleep(1);
+
+        expect(nextMock).toHaveBeenCalledTimes(1);
+        expect(nextMock).toHaveBeenCalledWith();
+        expect(contentType).toHaveBeenCalledWith('application/json');
+    });
+});

--- a/src/router/middlewares/setContentType.ts
+++ b/src/router/middlewares/setContentType.ts
@@ -1,0 +1,22 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+import express from 'express';
+
+/**
+ * Set default content-type to 'application/fhir+json'
+ */
+export const setContentTypeMiddleware = (req: express.Request, res: express.Response, next: express.NextFunction) => {
+    try {
+        res.contentType(
+            req.headers['content-type'] === 'application/json' ? 'application/json' : 'application/fhir+json',
+        );
+        next();
+    } catch (e) {
+        next(e);
+    }
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -1644,7 +1644,7 @@ compare-func@^2.0.0:
     array-ify "^1.0.0"
     dot-prop "^5.1.0"
 
-component-emitter@^1.2.1:
+component-emitter@^1.2.1, component-emitter@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.3.0.tgz#16e4070fba8ae29b679f2215853ee181ab2eabc0"
   integrity sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==
@@ -1860,6 +1860,11 @@ cookie@0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.4.0.tgz#beb437e7022b3b6d49019d088665303ebe9c14ba"
   integrity sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg==
+
+cookiejar@^2.1.2:
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/cookiejar/-/cookiejar-2.1.3.tgz#fc7a6216e408e74414b90230050842dacda75acc"
+  integrity sha512-JxbCBUdrfr6AQjOXrxoTvAMJO4HBTUIlBzslcJPAz+/KT8yk53fXun51u+RenNYvad/+Vc2DIz5o9UxlCDymFQ==
 
 copy-descriptor@^0.1.0:
   version "0.1.1"
@@ -2587,6 +2592,11 @@ fast-levenshtein@^2.0.6, fast-levenshtein@~2.0.6:
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
   integrity sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=
 
+fast-safe-stringify@^2.0.7:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz#c406a83b6e70d9e35ce3b30a81141df30aeba884"
+  integrity sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==
+
 fastq@^1.6.0:
   version "1.13.0"
   resolved "https://registry.yarnpkg.com/fastq/-/fastq-1.13.0.tgz#616760f88a7526bdfc596b7cab8c18938c36b98c"
@@ -2724,6 +2734,11 @@ form-data@^3.0.0:
     asynckit "^0.4.0"
     combined-stream "^1.0.8"
     mime-types "^2.1.12"
+
+formidable@^1.2.2:
+  version "1.2.6"
+  resolved "https://registry.yarnpkg.com/formidable/-/formidable-1.2.6.tgz#d2a51d60162bbc9b4a055d8457a7c75315d1a168"
+  integrity sha512-KcpbcpuLNOwrEjnbpMC0gS+X8ciDoZE1kkqzat4a8vrprf+s9pKNQ/QIwWfbfs4ltgmFl3MD177SNTkve3BwGQ==
 
 forwarded@0.2.0:
   version "0.2.0"
@@ -4219,7 +4234,7 @@ merge2@^1.3.0:
   resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.4.1.tgz#4368892f885e907455a6fd7dc55c0c9d404990ae"
   integrity sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==
 
-methods@~1.1.2:
+methods@^1.1.2, methods@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/methods/-/methods-1.1.2.tgz#5529a4d67654134edcc5266656835b0f851afcee"
   integrity sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=
@@ -4267,6 +4282,11 @@ mime@1.6.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/mime/-/mime-1.6.0.tgz#32cd9e5c64553bd58d19a568af452acff04981b1"
   integrity sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==
+
+mime@^2.4.6:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/mime/-/mime-2.6.0.tgz#a2a682a95cd4d0cb1d6257e28f83da7e35800367"
+  integrity sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==
 
 mimic-fn@^2.1.0:
   version "2.1.0"
@@ -4952,6 +4972,13 @@ qs@6.7.0:
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.7.0.tgz#41dc1a015e3d581f1621776be31afb2876a9b1bc"
   integrity sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==
 
+qs@^6.9.4:
+  version "6.10.2"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.10.2.tgz#c1431bea37fc5b24c5bdbafa20f16bdf2a4b9ffe"
+  integrity sha512-mSIdjzqznWgfd4pMii7sHtaYF8rx8861hBO80SraY5GT0XQibWZWJSid0avzHGkDIZLImux2S5mXO0Hfct2QCw==
+  dependencies:
+    side-channel "^1.0.4"
+
 querystring@0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/querystring/-/querystring-0.2.0.tgz#b209849203bb25df820da756e747005878521620"
@@ -5023,7 +5050,7 @@ read-pkg@^5.2.0:
     parse-json "^5.0.0"
     type-fest "^0.6.0"
 
-readable-stream@3, readable-stream@^3.0.0, readable-stream@^3.0.2, readable-stream@^3.4.0:
+readable-stream@3, readable-stream@^3.0.0, readable-stream@^3.0.2, readable-stream@^3.4.0, readable-stream@^3.6.0:
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.6.0.tgz#337bbda3adc0706bd3e024426a286d4b4b2c9198"
   integrity sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==
@@ -5650,6 +5677,31 @@ strip-json-comments@^3.1.0, strip-json-comments@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.1.1.tgz#31f1281b3832630434831c310c01cccda8cbe006"
   integrity sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==
+
+superagent@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/superagent/-/superagent-6.1.0.tgz#09f08807bc41108ef164cfb4be293cebd480f4a6"
+  integrity sha512-OUDHEssirmplo3F+1HWKUrUjvnQuA+nZI6i/JJBdXb5eq9IyEQwPyPpqND+SSsxf6TygpBEkUjISVRN4/VOpeg==
+  dependencies:
+    component-emitter "^1.3.0"
+    cookiejar "^2.1.2"
+    debug "^4.1.1"
+    fast-safe-stringify "^2.0.7"
+    form-data "^3.0.0"
+    formidable "^1.2.2"
+    methods "^1.1.2"
+    mime "^2.4.6"
+    qs "^6.9.4"
+    readable-stream "^3.6.0"
+    semver "^7.3.2"
+
+supertest@^6.1.6:
+  version "6.1.6"
+  resolved "https://registry.yarnpkg.com/supertest/-/supertest-6.1.6.tgz#6151c518f4c5ced2ac2aadb9f96f1bf8198174c8"
+  integrity sha512-0hACYGNJ8OHRg8CRITeZOdbjur7NLuNs0mBjVhdpxi7hP6t3QIbOzLON5RTUmZcy2I9riuII3+Pr2C7yztrIIg==
+  dependencies:
+    methods "^1.1.2"
+    superagent "^6.1.0"
 
 supports-color@^5.3.0:
   version "5.5.0"


### PR DESCRIPTION
Issue #, if available:
#146 

Description of changes:
* Use `application/fhir+json` as default content-type
* Use `application/json` if request content-type is `application/json`
* Deployed and tested in AWS account 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.