### PR TITLE
feat: log cloudfront request headers

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -28,7 +28,7 @@ import { initializeOperationRegistry } from './operationDefinitions';
 import { setServerUrlMiddleware } from './router/middlewares/setServerUrl';
 import { setTenantIdMiddleware } from './router/middlewares/setTenantId';
 import { setContentTypeMiddleware } from './router/middlewares/setContentType';
-import getComponentLogger from './loggerBuilder'
+import getComponentLogger from './loggerBuilder';
 
 const configVersionSupported: ConfigVersion = 1;
 
@@ -87,11 +87,11 @@ export function generateServerlessRouter(
     // Log Geolocation headers
     if (headers) {
         const logger = getComponentLogger();
-        logger.log(headers["CloudFront-Viewer-Country"]);
-        logger.log(headers["CloudFront-Is-Desktop-Viewer"]);
-        logger.log(headers["CloudFront-Is-Mobile-Viewer"]);
-        logger.log(headers["CloudFront-Is-SmartTV-Viewer"]);
-        logger.log(headers["CloudFront-Is-Tablet-Viewer"]);
+        logger.log(headers['CloudFront-Viewer-Country']);
+        logger.log(headers['CloudFront-Is-Desktop-Viewer']);
+        logger.log(headers['CloudFront-Is-Mobile-Viewer']);
+        logger.log(headers['CloudFront-Is-SmartTV-Viewer']);
+        logger.log(headers['CloudFront-Is-Tablet-Viewer']);
     }
 
     mainRouter.use(setServerUrlMiddleware(fhirConfig));

--- a/src/app.ts
+++ b/src/app.ts
@@ -28,6 +28,7 @@ import { initializeOperationRegistry } from './operationDefinitions';
 import { setServerUrlMiddleware } from './router/middlewares/setServerUrl';
 import { setTenantIdMiddleware } from './router/middlewares/setTenantId';
 import { setContentTypeMiddleware } from './router/middlewares/setContentType';
+import getComponentLogger from './loggerBuilder'
 
 const configVersionSupported: ConfigVersion = 1;
 
@@ -51,6 +52,7 @@ function prepareRequestContext(req: express.Request): RequestContext {
 export function generateServerlessRouter(
     fhirConfig: FhirConfig,
     supportedGenericResources: string[],
+    headers?: any,
     corsOptions?: CorsOptions,
 ): Express {
     if (configVersionSupported !== fhirConfig.configVersion) {
@@ -80,6 +82,16 @@ export function generateServerlessRouter(
     if (corsOptions) {
         mainRouter.use(cors(corsOptions));
         hasCORSEnabled = true;
+    }
+
+    // Log Geolocation headers
+    if (headers) {
+        const logger = getComponentLogger();
+        logger.log(headers["CloudFront-Viewer-Country"]);
+        logger.log(headers["CloudFront-Is-Desktop-Viewer"]);
+        logger.log(headers["CloudFront-Is-Mobile-Viewer"]);
+        logger.log(headers["CloudFront-Is-SmartTV-Viewer"]);
+        logger.log(headers["CloudFront-Is-Tablet-Viewer"]);
     }
 
     mainRouter.use(setServerUrlMiddleware(fhirConfig));


### PR DESCRIPTION
Issue #136, if available:

Description of changes:
Modified fhir-service lambda in deployment package to also pass headers to routing package (from `event.headers`). This gives access to the CloudFront request headers that are attached by APIGateway. We may need to whitelist additional geolocation headers as well, as only `CloudFront-Viewer-Country` is present at the moment, and I'm not sure if that is sufficient for the ask.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.