### PR TITLE
feat: Feature/private api gateway

### DIFF
--- a/src/router/metadata/metadataHandler.test.ts
+++ b/src/router/metadata/metadataHandler.test.ts
@@ -797,7 +797,7 @@ test('R4: dynamic hostname used in implementation.url', async () => {
     const response = await metadataHandler.capabilities({
         fhirVersion: '4.0.1',
         mode: 'full',
-        hostName: 'different.host.example.com',
+        fhirServiceBaseUrl: 'https://different.host.example.com/mystage',
     });
 
     const expectedResponse: any = {
@@ -817,7 +817,7 @@ test('R4: dynamic hostname used in implementation.url', async () => {
         },
         implementation: {
             description: 'Product Description',
-            url: 'http://different.host.example.com',
+            url: 'https://different.host.example.com/mystage',
         },
         fhirVersion: '4.0.1',
         format: ['json'],

--- a/src/router/metadata/metadataHandler.ts
+++ b/src/router/metadata/metadataHandler.ts
@@ -2,9 +2,9 @@
  *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *  SPDX-License-Identifier: Apache-2.0
  */
-import { isNull, isUndefined } from 'lodash';
 import { Capabilities, CapabilitiesRequest, FhirVersion, GenericResponse } from 'fhir-works-on-aws-interface';
 import createError from 'http-errors';
+import { isUndefined } from 'lodash';
 import { makeGenericResources, makeResource } from './cap.rest.resource.template';
 import makeSecurity from './cap.rest.security.template';
 import makeRest from './cap.rest.template';
@@ -75,12 +75,10 @@ export default class MetadataHandler implements Capabilities {
 
         // determine if our implentation.url is a static tld or dynamic
         let serverUrl = server.url;
-        if (server.dynamicHostName && !isUndefined(request.hostName) && !isNull(request.hostName)) {
-            // use a dynamic impelmentation.url so clients to each TLD have dynamic cannonical URLs
-            const parsedUrl = new URL(server.url);
-            parsedUrl.hostname = request.hostName;
-            serverUrl = parsedUrl.href;
+        if (server.dynamicHostName && !isUndefined(request.fhirServiceBaseUrl)) {
+            serverUrl = request.fhirServiceBaseUrl;
         }
+
         const capStatement = makeStatement(rest, productInfo, serverUrl, request.fhirVersion);
 
         return {

--- a/src/router/middlewares/setServerUrl.test.ts
+++ b/src/router/middlewares/setServerUrl.test.ts
@@ -60,11 +60,11 @@ describe('createServerUrlMiddleware', () => {
         expect(res.locals.serverUrl).toEqual('https://fwoa.com/some/path');
     });
 
-    test('alternativeUrl host used', async () => {
+    test('dynamic host used', async () => {
         const fhirConfig = {
             server: {
                 url: 'https://fwoa.com',
-                alternativeUrls: ['https://private.api.gateway.example.com', 'https://custom.dns.example.com'],
+                dynamicHostName: true,
             },
         } as FhirConfig;
 
@@ -86,11 +86,11 @@ describe('createServerUrlMiddleware', () => {
         expect(res.locals.serverUrl).toEqual('https://private.api.gateway.example.com');
     });
 
-    test('alternativeUrl host used and path appended', async () => {
+    test('dynamic host used and path appended', async () => {
         const fhirConfig = {
             server: {
                 url: 'https://fwoa.com',
-                alternativeUrls: ['https://private.api.gateway.example.com', 'https://custom.dns.example.com'],
+                dynamicHostName: true,
             },
         } as FhirConfig;
 
@@ -112,18 +112,18 @@ describe('createServerUrlMiddleware', () => {
         expect(res.locals.serverUrl).toEqual('https://private.api.gateway.example.com/some/path');
     });
 
-    test('alternativeUrl host not used with no match', async () => {
+    test('dynamic host not used w/no host header', async () => {
         const fhirConfig = {
             server: {
                 url: 'https://fwoa.com',
-                alternativeUrls: ['https://private.api.gateway.example.com', 'https://custom.dns.example.com'],
+                dynamicHostName: true,
             },
         } as FhirConfig;
 
         const serverUrlMiddleware = setServerUrlMiddleware(fhirConfig);
 
         const nextMock = jest.fn();
-        const req = { baseUrl: '/', headers: { host: 'something.else.example.com' } } as unknown as express.Request;
+        const req = { baseUrl: '/', headers: {} } as unknown as express.Request;
         const res = {
             locals: {},
         } as unknown as express.Response;

--- a/src/router/middlewares/setServerUrl.test.ts
+++ b/src/router/middlewares/setServerUrl.test.ts
@@ -59,4 +59,79 @@ describe('createServerUrlMiddleware', () => {
         expect(nextMock).toHaveBeenCalledWith();
         expect(res.locals.serverUrl).toEqual('https://fwoa.com/some/path');
     });
+
+    test('alternativeUrl host used', async () => {
+        const fhirConfig = {
+            server: {
+                url: 'https://fwoa.com',
+                alternativeUrls: ['https://private.api.gateway.example.com', 'https://custom.dns.example.com'],
+            },
+        } as FhirConfig;
+
+        const serverUrlMiddleware = setServerUrlMiddleware(fhirConfig);
+
+        const nextMock = jest.fn();
+        const req = {
+            baseUrl: '/',
+            headers: { host: 'private.api.gateway.example.com' },
+        } as unknown as express.Request;
+        const res = {
+            locals: {},
+        } as unknown as express.Response;
+
+        await serverUrlMiddleware(req, res, nextMock);
+
+        expect(nextMock).toHaveBeenCalledTimes(1);
+        expect(nextMock).toHaveBeenCalledWith();
+        expect(res.locals.serverUrl).toEqual('https://private.api.gateway.example.com');
+    });
+
+    test('alternativeUrl host used and path appended', async () => {
+        const fhirConfig = {
+            server: {
+                url: 'https://fwoa.com',
+                alternativeUrls: ['https://private.api.gateway.example.com', 'https://custom.dns.example.com'],
+            },
+        } as FhirConfig;
+
+        const serverUrlMiddleware = setServerUrlMiddleware(fhirConfig);
+
+        const nextMock = jest.fn();
+        const req = {
+            baseUrl: '/some/path',
+            headers: { host: 'private.api.gateway.example.com' },
+        } as unknown as express.Request;
+        const res = {
+            locals: {},
+        } as unknown as express.Response;
+
+        await serverUrlMiddleware(req, res, nextMock);
+
+        expect(nextMock).toHaveBeenCalledTimes(1);
+        expect(nextMock).toHaveBeenCalledWith();
+        expect(res.locals.serverUrl).toEqual('https://private.api.gateway.example.com/some/path');
+    });
+
+    test('alternativeUrl host not used with no match', async () => {
+        const fhirConfig = {
+            server: {
+                url: 'https://fwoa.com',
+                alternativeUrls: ['https://private.api.gateway.example.com', 'https://custom.dns.example.com'],
+            },
+        } as FhirConfig;
+
+        const serverUrlMiddleware = setServerUrlMiddleware(fhirConfig);
+
+        const nextMock = jest.fn();
+        const req = { baseUrl: '/', headers: { host: 'something.else.example.com' } } as unknown as express.Request;
+        const res = {
+            locals: {},
+        } as unknown as express.Response;
+
+        await serverUrlMiddleware(req, res, nextMock);
+
+        expect(nextMock).toHaveBeenCalledTimes(1);
+        expect(nextMock).toHaveBeenCalledWith();
+        expect(res.locals.serverUrl).toEqual('https://fwoa.com');
+    });
 });

--- a/src/router/middlewares/setServerUrl.ts
+++ b/src/router/middlewares/setServerUrl.ts
@@ -7,8 +7,8 @@
 
 import { FhirConfig } from 'fhir-works-on-aws-interface';
 import express from 'express';
-import RouteHelper from '../routes/routeHelper';
 import { isEmpty, isUndefined } from 'lodash';
+import RouteHelper from '../routes/routeHelper';
 
 /**
  * Sets the value of `res.locals.serverUrl`
@@ -18,16 +18,17 @@ export const setServerUrlMiddleware: (
     fhirConfig: FhirConfig,
 ) => (req: express.Request, res: express.Response, next: express.NextFunction) => void = (fhirConfig: FhirConfig) => {
     return RouteHelper.wrapAsync(async (req: express.Request, res: express.Response, next: express.NextFunction) => {
-        let serverUrl = fhirConfig.server.url
-        if (!isEmpty(fhirConfig.server.alternativeUrls)){
-            const hostMatch = fhirConfig.server.alternativeUrls?.find((alternativeUrl: string)=>{
-                return alternativeUrl === req.headers.host;
+        let serverUrl = fhirConfig.server.url;
+        if (!isEmpty(fhirConfig.server.alternativeUrls)) {
+            const hostMatch = fhirConfig.server.alternativeUrls?.find((alternativeUrl: string) => {
+                const myUrl = new URL(alternativeUrl);
+                return myUrl.hostname === req.headers.host;
             });
-            if (!isUndefined(hostMatch)){
-                serverUrl = hostMatch; 
+            if (!isUndefined(hostMatch)) {
+                serverUrl = hostMatch;
             }
         }
-        
+
         if (req.baseUrl && req.baseUrl !== '/') {
             res.locals.serverUrl = serverUrl + req.baseUrl;
         } else {

--- a/src/router/middlewares/setServerUrl.ts
+++ b/src/router/middlewares/setServerUrl.ts
@@ -24,7 +24,12 @@ export const setServerUrlMiddleware: (
             // examples: private API gateway, custom DNS values, CNAMES
             const parsedUrl = new URL(serverUrl);
             parsedUrl.hostname = req.headers.host;
-            serverUrl = parsedUrl.href.substring(0, parsedUrl.href.length - 1);
+
+            // downstream code expects no trailing `/` char
+            serverUrl = parsedUrl.href;
+            if (serverUrl.endsWith('/')) {
+                serverUrl = serverUrl.substring(0, parsedUrl.href.length - 1);
+            }
         }
 
         if (req.baseUrl && req.baseUrl !== '/') {

--- a/src/router/routes/metadataRoute.ts
+++ b/src/router/routes/metadataRoute.ts
@@ -37,6 +37,7 @@ export default class MetadataRoute {
             const response = await this.metadataHandler.capabilities({
                 fhirVersion: this.fhirVersion,
                 mode,
+                hostName: req.headers.host,
             });
             res.send(response.resource);
         });

--- a/src/router/routes/metadataRoute.ts
+++ b/src/router/routes/metadataRoute.ts
@@ -37,7 +37,7 @@ export default class MetadataRoute {
             const response = await this.metadataHandler.capabilities({
                 fhirVersion: this.fhirVersion,
                 mode,
-                hostName: req.headers.host,
+                fhirServiceBaseUrl: res.locals.serverUrl,
             });
             res.send(response.resource);
         });


### PR DESCRIPTION
Issue #, if available:
https://github.com/awslabs/fhir-works-on-aws-deployment/issues/378

Description of changes:
Added logic to the setServerUrl middleware to dynamically compute the TLD based on the request's hostname if fwoa is currently configured to in server.dynamicHostName. This allows for supporting private API gateways, custom DNS and cname TLDs and fixes public API links being used in search bundle response's link values.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.