### PR TITLE
fix: fix content type for .well-known/smart-configuration

### DIFF
--- a/src/router/routes/wellKnownUriRoute.ts
+++ b/src/router/routes/wellKnownUriRoute.ts
@@ -21,6 +21,7 @@ export default class WellKnownUriRouteRoute {
     private init() {
         this.router.get('/', async (req: express.Request, res: express.Response) => {
             const response = getWellKnownUriResponse(this.smartStrategy);
+            res.contentType('application/json');
             res.send(response);
         });
     }


### PR DESCRIPTION
A previous change is non-conformant with the SMART spec: https://github.com/awslabs/fhir-works-on-aws-routing/pull/147
Inferno tests fail with:
```
fail - SD-01 FHIR server makes SMART configuration available from well-known endpoint
    Message: Expected content-type application/json but found application/fhir+json
```

It's fine to keep `application/fhir+json` as default content-type and just explicitly set it to something else when needed (like to `application/json` here), since `application/fhir+json` is correct in the vast majority of cases.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.