### PR TITLE
feat: add Batch support

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "cors": "^2.8.5",
     "errorhandler": "^1.5.1",
     "express": "^4.17.1",
-    "fhir-works-on-aws-interface": "^12.0.0",
+    "fhir-works-on-aws-interface": "^12.1.0",
     "flat": "^5.0.0",
     "http-errors": "^1.8.0",
     "lodash": "^4.17.15",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -4,3 +4,6 @@
  */
 
 export const MAX_BUNDLE_ENTRIES = 25;
+// Lambda payload limit is 6MB, assuming an average request of 4KB,
+// we have 6MB / 4Kb = 1500. Dividing by half to allow for contingencies, we have the following limit:
+export const MAX_BATCH_ENTRIES = 750;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -4,8 +4,3 @@
  */
 
 export const MAX_BUNDLE_ENTRIES = 25;
-// Lambda payload limit is 6MB, assuming an average request of 4KB,
-// we have 6MB / 4Kb = 1500. Dividing by half to allow for contingencies, we get 750.
-// This value is customizable during deployment by appending --maxBatchEntries <your value here>
-// if no param is defined during deployment, we use this default
-export const MAX_BATCH_ENTRIES = Number(process.env.MAX_BATCH_ENTRIES) || 750;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -5,5 +5,7 @@
 
 export const MAX_BUNDLE_ENTRIES = 25;
 // Lambda payload limit is 6MB, assuming an average request of 4KB,
-// we have 6MB / 4Kb = 1500. Dividing by half to allow for contingencies, we have the following limit:
-export const MAX_BATCH_ENTRIES = 750;
+// we have 6MB / 4Kb = 1500. Dividing by half to allow for contingencies, we get 750.
+// This value is customizable during deployment by appending --maxBatchEntries <your value here>
+// if no param is defined during deployment, we use this default
+export const MAX_BATCH_ENTRIES = Number(process.env.MAX_BATCH_ENTRIES) || 750;

--- a/src/router/__mocks__/dynamoDbBundleService.ts
+++ b/src/router/__mocks__/dynamoDbBundleService.ts
@@ -8,9 +8,80 @@ import {
     TransactionRequest,
 } from 'fhir-works-on-aws-interface';
 
+const bundleEntryResponses: BatchReadWriteResponse[] = [
+    {
+        id: '8cafa46d-08b4-4ee4-b51b-803e20ae8126',
+        vid: '3',
+        operation: 'update',
+        lastModified: '2020-04-23T21:19:35.592Z',
+        resourceType: 'Patient',
+        resource: {},
+    },
+    {
+        id: '7c7cf4ca-4ba7-4326-b0dd-f3275b735827',
+        vid: '1',
+        operation: 'create',
+        lastModified: '2020-04-23T21:19:35.592Z',
+        resourceType: 'Patient',
+        resource: {},
+    },
+    {
+        id: '47135b80-b721-430b-9d4b-1557edc64947',
+        vid: '1',
+        operation: 'read',
+        lastModified: '2020-04-10T20:41:39.912Z',
+        resource: {
+            active: true,
+            resourceType: 'Patient',
+            birthDate: '1995-09-24',
+            meta: {
+                lastUpdated: '2020-04-10T20:41:39.912Z',
+                versionId: '1',
+            },
+            managingOrganization: {
+                reference: 'Organization/2.16.840.1.113883.19.5',
+                display: 'Good Health Clinic',
+            },
+            text: {
+                div: '<div xmlns="http://www.w3.org/1999/xhtml"><p></p></div>',
+                status: 'generated',
+            },
+            id: '47135b80-b721-430b-9d4b-1557edc64947',
+            name: [
+                {
+                    family: 'Langard',
+                    given: ['Abby'],
+                },
+            ],
+            gender: 'female',
+        },
+        resourceType: 'Patient',
+    },
+    {
+        id: 'bce8411e-c15e-448c-95dd-69155a837405',
+        vid: '1',
+        operation: 'delete',
+        lastModified: '2020-04-23T21:19:35.593Z',
+        resource: {},
+        resourceType: 'Patient',
+    },
+];
+
 const DynamoDbBundleService: Bundle = class {
-    static batch(request: BatchRequest): Promise<BundleResponse> {
-        throw new Error('Method not implemented.');
+    static async batch(request: BatchRequest): Promise<BundleResponse> {
+        if (request.requests.length === 0) {
+            return {
+                success: true,
+                message: 'No requests to process',
+                batchReadWriteResponses: [],
+            };
+        }
+
+        return {
+            success: true,
+            message: 'successfully completed batch',
+            batchReadWriteResponses: bundleEntryResponses,
+        };
     }
 
     static async transaction(request: TransactionRequest): Promise<BundleResponse> {
@@ -22,64 +93,6 @@ const DynamoDbBundleService: Bundle = class {
             };
         }
 
-        const bundleEntryResponses: BatchReadWriteResponse[] = [
-            {
-                id: '8cafa46d-08b4-4ee4-b51b-803e20ae8126',
-                vid: '3',
-                operation: 'update',
-                lastModified: '2020-04-23T21:19:35.592Z',
-                resourceType: 'Patient',
-                resource: {},
-            },
-            {
-                id: '7c7cf4ca-4ba7-4326-b0dd-f3275b735827',
-                vid: '1',
-                operation: 'create',
-                lastModified: '2020-04-23T21:19:35.592Z',
-                resourceType: 'Patient',
-                resource: {},
-            },
-            {
-                id: '47135b80-b721-430b-9d4b-1557edc64947',
-                vid: '1',
-                operation: 'read',
-                lastModified: '2020-04-10T20:41:39.912Z',
-                resource: {
-                    active: true,
-                    resourceType: 'Patient',
-                    birthDate: '1995-09-24',
-                    meta: {
-                        lastUpdated: '2020-04-10T20:41:39.912Z',
-                        versionId: '1',
-                    },
-                    managingOrganization: {
-                        reference: 'Organization/2.16.840.1.113883.19.5',
-                        display: 'Good Health Clinic',
-                    },
-                    text: {
-                        div: '<div xmlns="http://www.w3.org/1999/xhtml"><p></p></div>',
-                        status: 'generated',
-                    },
-                    id: '47135b80-b721-430b-9d4b-1557edc64947',
-                    name: [
-                        {
-                            family: 'Langard',
-                            given: ['Abby'],
-                        },
-                    ],
-                    gender: 'female',
-                },
-                resourceType: 'Patient',
-            },
-            {
-                id: 'bce8411e-c15e-448c-95dd-69155a837405',
-                vid: '1',
-                operation: 'delete',
-                lastModified: '2020-04-23T21:19:35.593Z',
-                resource: {},
-                resourceType: 'Patient',
-            },
-        ];
         return {
             success: true,
             message: 'Successfully committed requests to DB',

--- a/src/router/bundle/bundleGenerator.ts
+++ b/src/router/bundle/bundleGenerator.ts
@@ -85,57 +85,12 @@ export default class BundleGenerator {
         };
     }
 
-    static generateTransactionBundle(baseUrl: string, bundleEntryResponses: BatchReadWriteResponse[]) {
+    static generateGenericBundle(baseUrl: string, bundleEntryResponses: BatchReadWriteResponse[], bundleType: string) {
         const id = uuidv4();
         const response = {
             resourceType: 'Bundle',
             id,
-            type: 'transaction-response',
-            link: [
-                {
-                    relation: 'self',
-                    url: baseUrl,
-                },
-            ],
-            entry: [],
-        };
-
-        const entries: any = [];
-        bundleEntryResponses.forEach((bundleEntryResponse) => {
-            let status = '200 OK';
-            if (bundleEntryResponse.operation === 'create') {
-                status = '201 Created';
-            } else if (
-                ['read', 'vread'].includes(bundleEntryResponse.operation) &&
-                isEmpty(bundleEntryResponse.resource)
-            ) {
-                status = '403 Forbidden';
-            }
-            const entry: any = {
-                response: {
-                    status,
-                    location: `${bundleEntryResponse.resourceType}/${bundleEntryResponse.id}`,
-                    etag: bundleEntryResponse.vid,
-                    lastModified: bundleEntryResponse.lastModified,
-                },
-            };
-            if (bundleEntryResponse.operation === 'read') {
-                entry.resource = bundleEntryResponse.resource;
-            }
-
-            entries.push(entry);
-        });
-
-        response.entry = entries;
-        return response;
-    }
-
-    static generateBatchBundle(baseUrl: string, bundleEntryResponses: BatchReadWriteResponse[]) {
-        const id = uuidv4();
-        const response = {
-            resourceType: 'Bundle',
-            id,
-            type: 'batch-response',
+            type: bundleType,
             link: [
                 {
                     relation: 'self',
@@ -166,7 +121,6 @@ export default class BundleGenerator {
                     lastModified: bundleEntryResponse.lastModified,
                 },
             };
-            
             if (bundleEntryResponse.operation === 'read') {
                 entry.resource = bundleEntryResponse.resource;
             }
@@ -176,5 +130,13 @@ export default class BundleGenerator {
 
         response.entry = entries;
         return response;
+    }
+
+    static generateTransactionBundle(baseUrl: string, bundleEntryResponses: BatchReadWriteResponse[]) {
+        return this.generateGenericBundle(baseUrl, bundleEntryResponses, 'transaction-response');
+    }
+
+    static generateBatchBundle(baseUrl: string, bundleEntryResponses: BatchReadWriteResponse[]) {
+        return this.generateGenericBundle(baseUrl, bundleEntryResponses, 'batch-response');
     }
 }

--- a/src/router/bundle/bundleGenerator.ts
+++ b/src/router/bundle/bundleGenerator.ts
@@ -155,7 +155,7 @@ export default class BundleGenerator {
                 isEmpty(bundleEntryResponse.resource)
             ) {
                 status = '403 Forbidden';
-            } else if (bundleEntryResponse.operation === undefined || bundleEntryResponse.vid === '') {
+            } else if (bundleEntryResponse.vid === '') {
                 status = '404 Not Found';
             }
             const entry: any = {

--- a/src/router/bundle/bundleGenerator.ts
+++ b/src/router/bundle/bundleGenerator.ts
@@ -166,11 +166,7 @@ export default class BundleGenerator {
                     lastModified: bundleEntryResponse.lastModified,
                 },
             };
-            // remove unnecessary fields from response
-            if (bundleEntryResponse.error) {
-                entry.response.etag = undefined;
-                entry.response.lastModified = undefined;
-            }
+            
             if (bundleEntryResponse.operation === 'read') {
                 entry.resource = bundleEntryResponse.resource;
             }

--- a/src/router/bundle/bundleGenerator.ts
+++ b/src/router/bundle/bundleGenerator.ts
@@ -155,6 +155,8 @@ export default class BundleGenerator {
                 isEmpty(bundleEntryResponse.resource)
             ) {
                 status = '403 Forbidden';
+            } else if (bundleEntryResponse.operation === undefined || bundleEntryResponse.vid === '') {
+                status = '404 Not Found';
             }
             const entry: any = {
                 response: {

--- a/src/router/bundle/bundleGenerator.ts
+++ b/src/router/bundle/bundleGenerator.ts
@@ -148,15 +148,15 @@ export default class BundleGenerator {
         const entries: any = [];
         bundleEntryResponses.forEach((bundleEntryResponse) => {
             let status = '200 OK';
-            if (bundleEntryResponse.operation === 'create') {
+            if (bundleEntryResponse.error) {
+                status = bundleEntryResponse.error;
+            } else if (bundleEntryResponse.operation === 'create') {
                 status = '201 Created';
             } else if (
                 ['read', 'vread'].includes(bundleEntryResponse.operation) &&
                 isEmpty(bundleEntryResponse.resource)
             ) {
                 status = '403 Forbidden';
-            } else if (bundleEntryResponse.vid === '') {
-                status = '404 Not Found';
             }
             const entry: any = {
                 response: {
@@ -166,6 +166,11 @@ export default class BundleGenerator {
                     lastModified: bundleEntryResponse.lastModified,
                 },
             };
+            // remove unnecessary fields from response
+            if (bundleEntryResponse.error) {
+                entry.response.etag = undefined;
+                entry.response.lastModified = undefined;
+            }
             if (bundleEntryResponse.operation === 'read') {
                 entry.resource = bundleEntryResponse.resource;
             }

--- a/src/router/bundle/bundleHandler.test.ts
+++ b/src/router/bundle/bundleHandler.test.ts
@@ -813,6 +813,14 @@ describe('ERROR Cases: Bundle not authorized', () => {
                 dummyServerUrl,
             ),
         ).rejects.toThrowError(new UnauthorizedError('An entry within the Bundle is not authorized'));
+        await expect(
+            bundleHandlerWithStubbedAuthZ.processBatch(
+                bundleRequestJSON,
+                practitionerDecoded,
+                dummyRequestContext,
+                dummyServerUrl,
+            ),
+        ).rejects.toThrowError(new UnauthorizedError('An entry within the Bundle is not authorized'));
     });
 
     test('After filtering Bundle, read request is not Authorized', async () => {
@@ -901,6 +909,15 @@ describe('ERROR Cases: Bundle not authorized', () => {
         };
         await expect(
             bundleHandlerWithStubbedAuthZ.processTransaction(
+                bundleRequestJSON,
+                practitionerDecoded,
+                dummyRequestContext,
+                dummyServerUrl,
+            ),
+        ).resolves.toMatchObject(expectedResult);
+        expectedResult.type = 'batch-response';
+        await expect(
+            bundleHandlerWithStubbedAuthZ.processBatch(
                 bundleRequestJSON,
                 practitionerDecoded,
                 dummyRequestContext,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2616,10 +2616,10 @@ fecha@^4.2.0:
   resolved "https://registry.yarnpkg.com/fecha/-/fecha-4.2.1.tgz#0a83ad8f86ef62a091e22bb5a039cd03d23eecce"
   integrity sha512-MMMQ0ludy/nBs1/o0zVOiKTpG7qMbonKUzjJgQFEuvq6INZ1OraKPRAWkBq5vlKLOUMpmNYG1JoN3oDPUQ9m3Q==
 
-fhir-works-on-aws-interface@^12.0.0:
-  version "12.0.0"
-  resolved "https://registry.yarnpkg.com/fhir-works-on-aws-interface/-/fhir-works-on-aws-interface-12.0.0.tgz#3e9149ab953c5d3fd27bc8bb63b92e541057697f"
-  integrity sha512-gr5vFyEyktPgL6XPOTcbRqTQxOdJgB0QF8+q6nvto+hoAi30SH5YIYoJnsnX2ZM1ECnkSSeakMK2RbAVM6nImg==
+fhir-works-on-aws-interface@^12.1.0:
+  version "12.1.0"
+  resolved "https://registry.yarnpkg.com/fhir-works-on-aws-interface/-/fhir-works-on-aws-interface-12.1.0.tgz#74ff054cdf22eae0122c9ec32562475bcdd2cccf"
+  integrity sha512-LYbmbNz+CzPvH0QH+Sn8zEFzdfSUDd17hC5xjbMrxHOzQSuNEpIELbQ/rdtiNXc+V3xFsQubYsXoHl69wHZN3w==
   dependencies:
     winston "^3.3.3"
     winston-transport "^4.4.0"


### PR DESCRIPTION
Issue #, if available:

Description of changes:
Added logic to parse requests made to the root URL with a Batch request. Contains logic to validate the bundle according to https://www.hl7.org/fhir/http.html#brules, and adds unit tests for batch. This PR is in draft until the persistence changes are released and updated on the interface package.

We use a limit of 750 requests per bundle for the following reason:
Lambda has a payload limit of 6MB. Taking an average request size of 4KB, this gives us that 6MB/4KB = 1500 requests. To give some leeway, we divide by half to get 750.

TESTING:
tested through deployment and querying for various different bundle configurations such as:
- batches with references to resource within the bundle
- all different CRUD operations
- failing CRUD operations should not affect bundle success

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.