### PR TITLE
Feature/multi tenancy addons

### DIFF
--- a/sampleData/r4FhirConfigGenericMultiTenancy.ts
+++ b/sampleData/r4FhirConfigGenericMultiTenancy.ts
@@ -1,0 +1,59 @@
+import {
+    Authorization,
+    BulkDataAccess,
+    Bundle,
+    FhirConfig,
+    History,
+    Persistence,
+    Search,
+    stubs as fwoaStubs,
+} from 'fhir-works-on-aws-interface';
+
+const config = (stubs: {
+    bundle: Bundle;
+    search: Search;
+    history: History;
+    passThroughAuthz: Authorization;
+    persistence: Persistence;
+    bulkDataAccess: BulkDataAccess;
+}): FhirConfig => ({
+    configVersion: 1,
+    validators: [],
+    productInfo: {
+        orgName: 'Organization Name',
+    },
+    auth: {
+        strategy: {},
+        authorization: stubs.passThroughAuthz,
+    },
+    server: {
+        url: 'http://example.com',
+    },
+    profile: {
+        fhirVersion: '4.0.1',
+        systemOperations: ['transaction'],
+        bundle: stubs.bundle,
+        systemSearch: stubs.search,
+        systemHistory: stubs.history,
+        genericResource: {
+            operations: ['create', 'read', 'update', 'patch', 'delete', 'vread', 'search-type', 'history-instance'],
+            fhirVersions: ['4.0.1'],
+            persistence: stubs.persistence,
+            typeSearch: stubs.search,
+            typeHistory: stubs.history,
+        },
+    },
+    multiTenancyConfig: {
+        enableMultiTenancy: true,
+        useTenantSpecificUrl: true,
+        tenantIdClaimPath: 'cognito:groups',
+        tenantIdClaimValuePrefix: 'tenantprefix:',
+        grantAccessAllTenantsScope: 'tenants/all',
+    },
+});
+
+const configFn = (overrideStubs?: any) => {
+    return config({ ...fwoaStubs, ...overrideStubs });
+};
+
+export default configFn;

--- a/src/app.multitenancy.test.ts
+++ b/src/app.multitenancy.test.ts
@@ -1,0 +1,419 @@
+import express from 'express';
+import { clone, BatchReadWriteResponse } from 'fhir-works-on-aws-interface';
+import { generateServerlessRouter } from './app';
+import r4FhirConfigGenericMultiTenancy from '../sampleData/r4FhirConfigGenericMultiTenancy';
+import ElasticSearchService, { setExpectedSearchSet } from './router/__mocks__/elasticSearchService';
+import DynamoDbDataService, { setExpectedCreateResourceId } from './router/__mocks__/dynamoDbDataService';
+import DynamoDbBundleService, { setExpectedBundleEntryResponses } from './router/__mocks__/dynamoDbBundleService';
+import AuthorizationService, { setExpectedTokenDecoded } from './router/__mocks__/authorizationService';
+import validPatient from '../sampleData/validV4Patient.json';
+
+// eslint-disable-next-line import/no-unresolved
+const resourceType: string = 'Patient';
+const resourceId: string = '12345';
+const defaultTenantId: string = 'DEFAULT';
+const specificTenantId: string = '915b76f7-8744-4010-bd31-a1e4c0d9fc64';
+const wrongTenantId: string = '1234567890';
+const anyTenantId: string = '09876543';
+
+const request = require('supertest');
+
+function provideDecodedToken(scopes: string[]) {
+    return {
+        sub: 'fake',
+        name: 'not real',
+        iat: 1516239022,
+        'cognito:groups': [
+            'tenantprefix:915b76f7-8744-4010-bd31-a1e4c0d9fc64',
+            'tenantprefix:125545f5-e7e3-4868-898d-092f1023344b',
+            'tenantprefix:fe470d0a-c7e9-4857-a39c-9a06f68b517b',
+            'practitioner',
+        ],
+        scope: scopes,
+    };
+}
+
+const postResource = async (
+    app: express.Express,
+    resourceTypeToUse: string,
+    tenantId: string,
+    body: any,
+    expectedResourceId: string,
+    expectedStatusCode: number,
+) => {
+    const requestWithSupertest = request(app);
+    const res = await requestWithSupertest
+        .post(`/tenant/${tenantId}/${resourceTypeToUse}`)
+        .set('Content-Type', 'application/json')
+        .send(JSON.stringify(body));
+
+    expect(res.statusCode).toEqual(expectedStatusCode);
+    expect(res.headers['content-type']).toEqual('application/json; charset=utf-8');
+    expect(res.body.id).toEqual(expectedResourceId);
+    return res;
+};
+
+const postBundle = async (
+    app: express.Express,
+    tenantId: string,
+    body: any,
+    bundleEntryResponses: BatchReadWriteResponse[],
+    expectedStatusCode: number,
+) => {
+    const requestWithSupertest = request(app);
+    const res = await requestWithSupertest
+        .post(`/tenant/${tenantId}`)
+        .set('Content-Type', 'application/json')
+        .send(JSON.stringify(body));
+
+    expect(res.statusCode).toEqual(expectedStatusCode);
+    expect(res.headers['content-type']).toEqual('application/json; charset=utf-8');
+    expect(res.body.link[0].url).toEqual(expect.stringContaining(`/tenant/${tenantId}`));
+    expect(res.body.entry.length).toEqual(bundleEntryResponses.length);
+    expect(res.body.entry[0].response.location).toEqual(
+        `${bundleEntryResponses[0].resourceType}/${bundleEntryResponses[0].id}`,
+    );
+    expect(res.body.entry[0].response.etag).toEqual(bundleEntryResponses[0].vid);
+    expect(res.body.entry[0].response.status.toLowerCase()).toEqual(
+        expect.stringContaining(bundleEntryResponses[0].operation),
+    );
+    return res;
+};
+
+const getResource = async (
+    app: express.Express,
+    resourceTypeToUse: string,
+    tenantId: string,
+    id: string,
+    expectedStatusCode: number,
+    textMsg?: string,
+) => {
+    const requestWithSupertest = request(app);
+    const res = await requestWithSupertest
+        .get(`/tenant/${tenantId}/${resourceTypeToUse}/${id}`)
+        .set('Content-Type', 'application/json')
+        .send();
+
+    expect(res.statusCode).toEqual(expectedStatusCode);
+    if (res.statusCode < 301) {
+        expect(res.statusCode).toEqual(expectedStatusCode);
+    }
+    if (res.statusCode === 400) {
+        expect(res.body.issue[0].diagnostics).toContain(textMsg);
+    }
+    if (res.statusCode === 401) {
+        expect(res.text).toContain(textMsg);
+    }
+    return res;
+};
+
+const typeSearch = async (
+    app: express.Express,
+    resourceTypeToUse: string,
+    tenantId: string,
+    queryparams: string,
+    expectedStatusCode: number,
+    textMsg?: string,
+) => {
+    const requestWithSupertest = request(app);
+    const res = await requestWithSupertest
+        .get(`/tenant/${tenantId}/${resourceTypeToUse}?${encodeURIComponent(queryparams)}`)
+        .set('Content-Type', 'application/json')
+        .send();
+
+    expect(res.statusCode).toEqual(expectedStatusCode);
+    if (res.statusCode < 301) {
+        expect(res.statusCode).toEqual(expectedStatusCode);
+        expect(res.body.link[0].url).toEqual(expect.stringContaining(`/tenant/${tenantId}`));
+        expect(res.body.entry.length).toEqual(1);
+        expect(res.body.entry[0].fullUrl).toEqual(expect.stringContaining(`/tenant/${tenantId}`));
+    }
+    if (res.statusCode === 400) {
+        expect(res.body.issue[0].diagnostics).toContain(textMsg);
+    }
+    if (res.statusCode === 401) {
+        expect(res.text).toContain(textMsg);
+    }
+    return res;
+};
+
+const putResource = async (
+    app: express.Express,
+    resourceTypeToUse: string,
+    tenantId: string,
+    id: string,
+    body: any,
+    expectedStatusCode: number,
+) => {
+    const overrideResource = clone(body);
+    overrideResource.id = id;
+    const requestWithSupertest = request(app);
+    const res = await requestWithSupertest
+        .put(`/tenant/${tenantId}/${resourceTypeToUse}/${id}`)
+        .set('Content-Type', 'application/json')
+        .send(JSON.stringify(overrideResource));
+
+    expect(res.statusCode).toEqual(expectedStatusCode);
+    expect(res.headers['content-type']).toEqual('application/json; charset=utf-8');
+    expect(res.body.id).toEqual(id);
+    return res;
+};
+
+const patchResource = async (
+    app: express.Express,
+    resourceTypeToUse: string,
+    tenantId: string,
+    id: string,
+    body: any,
+    expectedStatusCode: number,
+) => {
+    const patchedResource = clone(body);
+    patchedResource.id = id;
+    const requestWithSupertest = request(app);
+    const res = await requestWithSupertest
+        .patch(`/tenant/${tenantId}/${resourceTypeToUse}/${id}`)
+        .set('Content-Type', 'application/json')
+        .send(JSON.stringify(patchedResource));
+
+    expect(res.statusCode).toEqual(expectedStatusCode);
+    expect(res.headers['content-type']).toEqual('application/json; charset=utf-8');
+    expect(res.body.id).toEqual(id);
+    return res;
+};
+const deleteResource = async (
+    app: express.Express,
+    resourceTypeToUse: string,
+    tenantId: string,
+    id: string,
+    expectedStatusCode: number,
+) => {
+    const requestWithSupertest = request(app);
+    const res = await requestWithSupertest
+        .delete(`/tenant/${tenantId}/${resourceTypeToUse}/${id}`)
+        .set('Content-Type', 'application/json')
+        .send();
+
+    expect(res.statusCode).toEqual(expectedStatusCode);
+};
+
+describe('Multi tenancy: generateServerlessRouter CRUD operations', () => {
+    const fhirConfig = r4FhirConfigGenericMultiTenancy({
+        passThroughAuthz: AuthorizationService,
+        search: ElasticSearchService,
+        persistence: DynamoDbDataService,
+    });
+    const app = generateServerlessRouter(fhirConfig, ['Patient']);
+
+    test(`Get: /${specificTenantId}/${resourceType}/${resourceId} should return 200.`, async () => {
+        setExpectedTokenDecoded(provideDecodedToken(['profile', 'openid']));
+
+        await getResource(app, resourceType, specificTenantId, resourceId, 200);
+    });
+
+    test(`Get: /${defaultTenantId}/${resourceType}/${resourceId} should return 200.`, async () => {
+        setExpectedTokenDecoded(provideDecodedToken(['profile', 'openid']));
+
+        await getResource(app, resourceType, defaultTenantId, resourceId, 200);
+    });
+
+    test(`Post: /${specificTenantId}/${resourceType} should return 201.`, async () => {
+        setExpectedCreateResourceId(resourceId);
+        setExpectedTokenDecoded(provideDecodedToken(['profile', 'openid']));
+
+        await postResource(app, resourceType, specificTenantId, validPatient, resourceId, 201);
+    });
+
+    test(`Post: /${defaultTenantId}/${resourceType} should return 201.`, async () => {
+        setExpectedCreateResourceId(resourceId);
+        setExpectedTokenDecoded(provideDecodedToken(['profile', 'openid']));
+
+        await postResource(app, resourceType, defaultTenantId, validPatient, resourceId, 201);
+    });
+
+    test(`Put: /${specificTenantId}/${resourceType} should return 200.`, async () => {
+        setExpectedCreateResourceId(resourceId);
+        setExpectedTokenDecoded(provideDecodedToken(['profile', 'openid']));
+
+        await putResource(app, resourceType, specificTenantId, resourceId, validPatient, 200);
+    });
+
+    test(`Put: /${defaultTenantId}/${resourceType} should return 200.`, async () => {
+        setExpectedCreateResourceId(resourceId);
+        setExpectedTokenDecoded(provideDecodedToken(['profile', 'openid']));
+
+        await putResource(app, resourceType, defaultTenantId, resourceId, validPatient, 200);
+    });
+
+    test(`Patch: /${specificTenantId}/${resourceType} should return 200.`, async () => {
+        setExpectedCreateResourceId(resourceId);
+        setExpectedTokenDecoded(provideDecodedToken(['profile', 'openid']));
+
+        await patchResource(app, resourceType, specificTenantId, resourceId, validPatient, 200);
+    });
+
+    test(`Patch: /${defaultTenantId}/${resourceType} should return 200.`, async () => {
+        setExpectedCreateResourceId(resourceId);
+        setExpectedTokenDecoded(provideDecodedToken(['profile', 'openid']));
+
+        await patchResource(app, resourceType, defaultTenantId, resourceId, validPatient, 200);
+    });
+
+    test(`Delete: /${specificTenantId}/${resourceType} should return 200.`, async () => {
+        setExpectedCreateResourceId(resourceId);
+        setExpectedTokenDecoded(provideDecodedToken(['profile', 'openid']));
+
+        await deleteResource(app, resourceType, specificTenantId, resourceId, 200);
+    });
+
+    test(`Delete: /${defaultTenantId}/${resourceType} should return 200.`, async () => {
+        setExpectedCreateResourceId(resourceId);
+        setExpectedTokenDecoded(provideDecodedToken(['profile', 'openid']));
+
+        await deleteResource(app, resourceType, defaultTenantId, resourceId, 200);
+    });
+});
+
+describe('Multi tenancy: generateServerlessRouter metadata access', () => {
+    const fhirConfig = r4FhirConfigGenericMultiTenancy({
+        passThroughAuthz: AuthorizationService,
+        search: ElasticSearchService,
+        persistence: DynamoDbDataService,
+    });
+    const app = generateServerlessRouter(fhirConfig, ['Patient']);
+
+    test(`Get: /${specificTenantId}/metadata should return 200.`, async () => {
+        const requestWithSupertest = request(app);
+        const res = await requestWithSupertest
+            .get(`/tenant/${specificTenantId}/metadata`)
+            .set('Content-Type', 'application/json')
+            .send();
+
+        expect(res.statusCode).toEqual(200);
+    });
+
+    test(`Get: /${defaultTenantId}/metadata should return 200.`, async () => {
+        const requestWithSupertest = request(app);
+        const res = await requestWithSupertest
+            .get(`/tenant/${defaultTenantId}/metadata`)
+            .set('Content-Type', 'application/json')
+            .send();
+
+        expect(res.statusCode).toEqual(200);
+    });
+});
+
+describe('Multi tenancy: generateServerlessRouter typesearch', () => {
+    const fhirConfig = r4FhirConfigGenericMultiTenancy({
+        passThroughAuthz: AuthorizationService,
+        search: ElasticSearchService,
+        persistence: DynamoDbDataService,
+    });
+    const app = generateServerlessRouter(fhirConfig, ['Patient']);
+    const queryParam =
+        'identifier=https://github.com/synthetichealth/synthea|e531c09f-6887-6aba-af17-cbc521900b87&birthdate=1992-08-02&family=Simpson&given=Lisa';
+
+    test(`Get: search /${specificTenantId}/${resourceType}?${queryParam} should return 200.`, async () => {
+        setExpectedTokenDecoded(provideDecodedToken(['profile', 'openid']));
+        setExpectedSearchSet([
+            {
+                fullUrl: 'Patient/cc8b9b47-f2a2-4779-b45a-6b18e6310aab',
+                resource: {
+                    resourceType: 'Patient',
+                    id: 'cc8b9b47-f2a2-4779-b45a-6b18e6310aab',
+                    meta: {
+                        versionId: 'dfcc8fb7-ceae-44d2-8a3b-70903f3b89bc',
+                        lastUpdated: '2021-08-18T12:49:12.757+00:00',
+                        source: '#qLEZvGrdkonQ2ihA',
+                    },
+                    text: {
+                        status: 'generated',
+                        div: '',
+                    },
+                    identifier: [
+                        {
+                            system: 'https://github.com/synthetichealth/synthea',
+                            value: 'e531c09f-6887-6aba-af17-cbc521900b87',
+                        },
+                    ],
+                    name: [
+                        {
+                            use: 'official',
+                            family: 'Simpson',
+                            given: ['Lisa'],
+                            prefix: ['Ms.'],
+                        },
+                    ],
+                    gender: 'female',
+                    birthDate: '1992-08-02',
+                },
+                search: {
+                    mode: 'match',
+                },
+            },
+        ]);
+
+        await typeSearch(app, resourceType, specificTenantId, queryParam, 200);
+    });
+});
+
+describe('Multi tenancy: generateServerlessRouter bundle transaction', () => {
+    const fhirConfig = r4FhirConfigGenericMultiTenancy({
+        passThroughAuthz: AuthorizationService,
+        search: ElasticSearchService,
+        persistence: DynamoDbDataService,
+        bundle: DynamoDbBundleService,
+    });
+
+    const bundle = {
+        resourceType: 'Bundle',
+        type: 'transaction',
+        entry: [
+            {
+                resource: validPatient,
+                request: {
+                    method: 'POST',
+                    url: 'Patient',
+                },
+            },
+        ],
+    };
+    const bundleEntryResponses: BatchReadWriteResponse[] = [
+        {
+            id: '8cafa46d-08b4-4ee4-b51b-803e20ae8126',
+            vid: '1',
+            operation: 'create',
+            lastModified: '2020-04-23T21:19:35.592Z',
+            resourceType: 'Patient',
+            resource: {},
+        },
+    ];
+
+    const app = generateServerlessRouter(fhirConfig, ['Patient', 'Bundle']);
+
+    test(`Post: bundle /${specificTenantId} should return 200.`, async () => {
+        setExpectedTokenDecoded(provideDecodedToken(['profile', 'openid']));
+        setExpectedBundleEntryResponses(bundleEntryResponses);
+
+        await postBundle(app, specificTenantId, bundle, bundleEntryResponses, 200);
+    });
+});
+
+describe('Multi tenancy: generateServerlessRouter authorization checks', () => {
+    const fhirConfig = r4FhirConfigGenericMultiTenancy({
+        passThroughAuthz: AuthorizationService,
+        search: ElasticSearchService,
+        persistence: DynamoDbDataService,
+    });
+    const app = generateServerlessRouter(fhirConfig, ['Patient']);
+
+    test(`Get: wrong tenant /${wrongTenantId}/${resourceType}/${resourceId} should return 401.`, async () => {
+        setExpectedTokenDecoded(provideDecodedToken(['profile', 'openid']));
+
+        await getResource(app, resourceType, wrongTenantId, resourceId, 401, 'Unauthorized');
+    });
+
+    test(`Get: tenants/all /${anyTenantId}/${resourceType}/${resourceId} should return 200.`, async () => {
+        setExpectedTokenDecoded(provideDecodedToken(['tenants/all', 'profile', 'openid']));
+        await getResource(app, resourceType, wrongTenantId, resourceId, 200);
+    });
+});

--- a/src/router/__mocks__/authorizationService.ts
+++ b/src/router/__mocks__/authorizationService.ts
@@ -19,16 +19,15 @@ export function setExpectedTokenDecoded(newTokenDecoded: any): void {
 }
 const AuthorizationService: Authorization = class {
     static async verifyAccessToken(request: VerifyAccessTokenRequest): Promise<KeyValueMap> {
-        if (!expectedtokenDecoded) {
-            const practitionerDecoded = {
-                sub: 'fake',
-                'cognito:groups': ['practitioner'],
-                name: 'not real',
-                iat: 1516239022,
-            };
-            return practitionerDecoded;
+        if (expectedtokenDecoded) {
+            return expectedtokenDecoded;
         }
-        return expectedtokenDecoded;
+        return {
+            sub: 'fake',
+            'cognito:groups': ['practitioner'],
+            name: 'not real',
+            iat: 1516239022,
+        };
     }
 
     // eslint-disable-next-line @typescript-eslint/no-empty-function

--- a/src/router/__mocks__/authorizationService.ts
+++ b/src/router/__mocks__/authorizationService.ts
@@ -1,0 +1,61 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import {
+    Authorization,
+    AuthorizationBundleRequest,
+    AllowedResourceTypesForOperationRequest,
+    ReadResponseAuthorizedRequest,
+    VerifyAccessTokenRequest,
+    WriteRequestAuthorizedRequest,
+    AccessBulkDataJobRequest,
+    KeyValueMap,
+    GetSearchFilterBasedOnIdentityRequest,
+    SearchFilter,
+} from 'fhir-works-on-aws-interface';
+
+let expectedtokenDecoded: any;
+
+export function setExpectedTokenDecoded(newTokenDecoded: any): void {
+    expectedtokenDecoded = newTokenDecoded;
+}
+const AuthorizationService: Authorization = class {
+    static async verifyAccessToken(request: VerifyAccessTokenRequest): Promise<KeyValueMap> {
+        if (!expectedtokenDecoded) {
+            const practitionerDecoded = {
+                sub: 'fake',
+                'cognito:groups': ['practitioner'],
+                name: 'not real',
+                iat: 1516239022,
+            };
+            return practitionerDecoded;
+        }
+        return expectedtokenDecoded;
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    static async isAccessBulkDataJobAllowed(request: AccessBulkDataJobRequest): Promise<void> {}
+
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    static async isBundleRequestAuthorized(request: AuthorizationBundleRequest): Promise<void> {}
+
+    static async authorizeAndFilterReadResponse(request: ReadResponseAuthorizedRequest): Promise<any> {
+        // Currently no additional filtering/checking is needed for RBAC
+        return request.readResponse;
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    static async isWriteRequestAuthorized(request: WriteRequestAuthorizedRequest): Promise<void> {}
+
+    static async getAllowedResourceTypesForOperation(
+        request: AllowedResourceTypesForOperationRequest,
+    ): Promise<string[]> {
+        return ['Patient', 'Observation', 'Questionnaire', 'QuestionnaireResponse', 'Practitioner'];
+    }
+
+    static async getSearchFilterBasedOnIdentity(
+        request: GetSearchFilterBasedOnIdentityRequest,
+    ): Promise<SearchFilter[]> {
+        return [];
+    }
+};
+
+export default AuthorizationService;

--- a/src/router/__mocks__/dynamoDbBundleService.ts
+++ b/src/router/__mocks__/dynamoDbBundleService.ts
@@ -8,6 +8,12 @@ import {
     TransactionRequest,
 } from 'fhir-works-on-aws-interface';
 
+let expectedBundleEntryResponses: BatchReadWriteResponse[] = [];
+
+export function setExpectedBundleEntryResponses(responses: BatchReadWriteResponse[]) {
+    expectedBundleEntryResponses = responses;
+}
+
 const DynamoDbBundleService: Bundle = class {
     static batch(request: BatchRequest): Promise<BundleResponse> {
         throw new Error('Method not implemented.');
@@ -83,7 +89,8 @@ const DynamoDbBundleService: Bundle = class {
         return {
             success: true,
             message: 'Successfully committed requests to DB',
-            batchReadWriteResponses: bundleEntryResponses,
+            batchReadWriteResponses:
+                expectedBundleEntryResponses.length !== 0 ? expectedBundleEntryResponses : bundleEntryResponses,
         };
     }
 };

--- a/src/router/__mocks__/dynamoDbDataService.ts
+++ b/src/router/__mocks__/dynamoDbDataService.ts
@@ -17,12 +17,18 @@ import {
 } from 'fhir-works-on-aws-interface';
 import validPatient from '../../../sampleData/validV4Patient.json';
 
+let createResourceId: string = 'id';
+
+export function setExpectedCreateResourceId(resourceId: string) {
+    createResourceId = resourceId;
+}
+
 const DynamoDbDataService: Persistence = class {
     static updateCreateSupported: boolean = false;
 
     static async createResource(request: CreateResourceRequest): Promise<GenericResponse> {
         const resourceCopy: any = clone(request.resource);
-        resourceCopy.id = request.id || 'id';
+        resourceCopy.id = request.id || createResourceId;
         resourceCopy.meta = generateMeta('1');
         return {
             message: 'Resource created',

--- a/src/router/__mocks__/elasticSearchService.ts
+++ b/src/router/__mocks__/elasticSearchService.ts
@@ -6,6 +6,12 @@ import {
     SearchCapabilityStatement,
 } from 'fhir-works-on-aws-interface';
 
+let expectedSearchSet: any[] = [];
+
+export function setExpectedSearchSet(entries: any[]) {
+    expectedSearchSet = entries;
+}
+
 const ElasticSearchService: Search = class {
     /*
     searchParams => {field: value}
@@ -15,9 +21,14 @@ const ElasticSearchService: Search = class {
         return {
             success: true,
             result: {
-                numberOfResults: 0,
+                numberOfResults: expectedSearchSet.length,
                 message: '',
-                entries: [],
+                entries: expectedSearchSet.map((x) => {
+                    // Adapt fullUrl with base server url
+                    const entry = x;
+                    entry.fullUrl = `${request.baseUrl}/${x.fullUrl}`;
+                    return entry;
+                }),
             },
         };
     }
@@ -28,7 +39,8 @@ const ElasticSearchService: Search = class {
     }
 
     static async getCapabilities(): Promise<SearchCapabilityStatement> {
-        throw new Error('Method not implemented.');
+        const dummy: SearchCapabilityStatement = {};
+        return dummy;
     }
 
     static validateSubscriptionSearchCriteria(searchCriteria: string): void {

--- a/src/router/bundle/bundleHandler.test.ts
+++ b/src/router/bundle/bundleHandler.test.ts
@@ -672,7 +672,7 @@ describe('SUCCESS Cases: Testing Batch with CRUD entries', () => {
             link: [
                 {
                     relation: 'self',
-                    url: 'https://API_URL.com',
+                    url: dummyServerUrl,
                 },
             ],
             entry: [],
@@ -697,7 +697,7 @@ describe('SUCCESS Cases: Testing Batch with CRUD entries', () => {
             link: [
                 {
                     relation: 'self',
-                    url: 'https://API_URL.com',
+                    url: dummyServerUrl,
                 },
             ],
             entry: [

--- a/src/router/bundle/bundleHandler.test.ts
+++ b/src/router/bundle/bundleHandler.test.ts
@@ -569,7 +569,7 @@ describe('SUCCESS Cases: Testing Bundle with CRUD entries', () => {
             link: [
                 {
                     relation: 'self',
-                    url: 'https://API_URL.com',
+                    url: dummyServerUrl,
                 },
             ],
             entry: [
@@ -652,7 +652,7 @@ describe('SUCCESS Cases: Testing Bundle with CRUD entries', () => {
             link: [
                 {
                     relation: 'self',
-                    url: 'https://API_URL.com',
+                    url: dummyServerUrl,
                 },
             ],
             entry: [],
@@ -756,7 +756,7 @@ describe('ERROR Cases: Bundle not authorized', () => {
             link: [
                 {
                     relation: 'self',
-                    url: 'https://API_URL.com',
+                    url: dummyServerUrl,
                 },
             ],
             entry: [

--- a/src/router/bundle/bundleHandler.ts
+++ b/src/router/bundle/bundleHandler.ts
@@ -132,7 +132,7 @@ export default class BundleHandler implements BundleHandlerInterface {
                 requests = await BundleParser.parseResource(
                     bundleRequestJson,
                     this.genericResource.persistence,
-                    this.serverUrl,
+                    serverUrl,
                 );
             } else {
                 throw new Error('Cannot process bundle');
@@ -203,6 +203,6 @@ export default class BundleHandler implements BundleHandlerInterface {
             bundleServiceResponse.batchReadWriteResponses[index] = entryResponse;
         });
 
-        return BundleGenerator.generateTransactionBundle(this.serverUrl, bundleServiceResponse.batchReadWriteResponses);
+        return BundleGenerator.generateTransactionBundle(serverUrl, bundleServiceResponse.batchReadWriteResponses);
     }
 }

--- a/src/router/middlewares/setTenantId.test.ts
+++ b/src/router/middlewares/setTenantId.test.ts
@@ -47,6 +47,110 @@ describe('SetTenantIdMiddleware', () => {
             expect(res.locals.tenantId).toEqual('t1');
         });
 
+        test('multiple tenantIds having prefixes in custom claim', async () => {
+            const fhirConfig = {
+                multiTenancyConfig: {
+                    enableMultiTenancy: true,
+                    tenantIdClaimPath: 'tenantId',
+                    tenantIdClaimValuePrefix: 'mytenant:',
+                },
+                server: {
+                    url: 'https://xxxx.execute-api.us-east-2.amazonaws.com/dev',
+                },
+            } as FhirConfig;
+
+            const setTenantIdMiddlewareFn = setTenantIdMiddleware(fhirConfig);
+            const nextMock = jest.fn();
+            const req = { params: { tenantIdFromPath: 't3' } } as unknown as express.Request;
+            const res = {
+                locals: {
+                    userIdentity: {
+                        claim1: 'val1',
+                        tenantId: ['t1', 'mytenant:t2', 'mytenant:t3'],
+                        aud: 'aud-Claim-That-Does-Not-Match-For-TenantId-Extraction',
+                    },
+                },
+            } as unknown as express.Response;
+
+            setTenantIdMiddlewareFn(req, res, nextMock);
+
+            await sleep(1);
+
+            expect(nextMock).toHaveBeenCalledTimes(1);
+            expect(nextMock).toHaveBeenCalledWith();
+            expect(res.locals.tenantId).toEqual('t3');
+        });
+
+        test('grant access for "DEFAULT" tenant', async () => {
+            const fhirConfig = {
+                multiTenancyConfig: {
+                    enableMultiTenancy: true,
+                    tenantIdClaimPath: 'tenantId',
+                    tenantIdClaimValuePrefix: 'mytenant:',
+                },
+                server: {
+                    url: 'https://xxxx.execute-api.us-east-2.amazonaws.com/dev',
+                },
+            } as FhirConfig;
+
+            const setTenantIdMiddlewareFn = setTenantIdMiddleware(fhirConfig);
+            const nextMock = jest.fn();
+            const req = { params: { tenantIdFromPath: 'DEFAULT' } } as unknown as express.Request;
+            const res = {
+                locals: {
+                    userIdentity: {
+                        claim1: 'val1',
+                        tenantId: ['t1', 'mytenant:t2', 'mytenant:t3'],
+                        aud: 'aud-Claim-That-Does-Not-Match-For-TenantId-Extraction',
+                    },
+                },
+            } as unknown as express.Response;
+
+            setTenantIdMiddlewareFn(req, res, nextMock);
+
+            await sleep(1);
+
+            expect(nextMock).toHaveBeenCalledTimes(1);
+            expect(nextMock).toHaveBeenCalledWith();
+            expect(res.locals.tenantId).toEqual('DEFAULT');
+        });
+
+        test('grant access for all tenants scope', async () => {
+            const fhirConfig = {
+                multiTenancyConfig: {
+                    enableMultiTenancy: true,
+                    tenantIdClaimPath: 'tenantId',
+                    tenantIdClaimValuePrefix: 'mytenant:',
+                    grantAccessAllTenantsScope: 'm2m/all',
+                },
+                server: {
+                    url: 'https://xxxx.execute-api.us-east-2.amazonaws.com/dev',
+                },
+            } as FhirConfig;
+
+            const setTenantIdMiddlewareFn = setTenantIdMiddleware(fhirConfig);
+            const nextMock = jest.fn();
+            const req = { params: { tenantIdFromPath: 'tx' } } as unknown as express.Request;
+            const res = {
+                locals: {
+                    userIdentity: {
+                        claim1: 'val1',
+                        tenantId: ['t1', 'mytenant:t2', 'mytenant:t3'],
+                        aud: 'aud-Claim-That-Does-Not-Match-For-TenantId-Extraction',
+                        scope: ['openid', 'FhirUser', 'm2m/all'],
+                    },
+                },
+            } as unknown as express.Response;
+
+            setTenantIdMiddlewareFn(req, res, nextMock);
+
+            await sleep(1);
+
+            expect(nextMock).toHaveBeenCalledTimes(1);
+            expect(nextMock).toHaveBeenCalledWith();
+            expect(res.locals.tenantId).toEqual('tx');
+        });
+
         test('simple tenantId in aud claim', async () => {
             const fhirConfig = {
                 multiTenancyConfig: {
@@ -265,6 +369,39 @@ describe('SetTenantIdMiddleware', () => {
                     userIdentity: {
                         claim1: 'val1',
                         tenantId: 't1',
+                        aud: 'https://xxxx.execute-api.us-east-2.amazonaws.com/dev',
+                    },
+                },
+            } as unknown as express.Response;
+
+            setTenantIdMiddlewareFn(req, res, nextMock);
+
+            await sleep(1);
+
+            expect(nextMock).toHaveBeenCalledTimes(1);
+            expect(nextMock).toHaveBeenCalledWith(new UnauthorizedError('Unauthorized'));
+        });
+
+        test('multiple tenant id candidates in token does not match tenantId in path', async () => {
+            const fhirConfig = {
+                multiTenancyConfig: {
+                    enableMultiTenancy: true,
+                    tenantIdClaimPath: 'tenantId',
+                    tenantIdClaimValuePrefix: 'mytenant:',
+                },
+                server: {
+                    url: 'https://xxxx.execute-api.us-east-2.amazonaws.com/dev',
+                },
+            } as FhirConfig;
+
+            const setTenantIdMiddlewareFn = setTenantIdMiddleware(fhirConfig);
+            const nextMock = jest.fn();
+            const req = { params: { tenantIdFromPath: 't2' } } as unknown as express.Request;
+            const res = {
+                locals: {
+                    userIdentity: {
+                        claim1: 'val1',
+                        tenantId: ['mytenant:t1', 'mytenant:t3'],
                         aud: 'https://xxxx.execute-api.us-east-2.amazonaws.com/dev',
                     },
                 },

--- a/src/router/middlewares/setTenantId.ts
+++ b/src/router/middlewares/setTenantId.ts
@@ -49,6 +49,92 @@ const getTenantIdFromAudClaim = (audClaim: any, baseUrl: string): string | undef
 };
 
 /**
+ * Evaluates if an all tenants scope matches with the configured one.
+ * @param userIdentity The decoded access token data.
+ * @param fhirConfig The config, which includes multi-tenant setup.
+ * @returns true access granted, false denied
+ */
+function grantAccessForAllTenants(userIdentity: any, fhirConfig: FhirConfig): boolean {
+    if (fhirConfig.multiTenancyConfig?.grantAccessAllTenantsScope) {
+        const scopes: string[] = userIdentity.scope ?? [];
+        if (scopes.includes(fhirConfig.multiTenancyConfig?.grantAccessAllTenantsScope)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+const getTenantIdFromCustomClaimValue = (tenantIdClaimValue: string, prefix?: string): string | undefined => {
+    if (!prefix) {
+        return tenantIdClaimValue;
+    }
+
+    if (tenantIdClaimValue.startsWith(prefix)) {
+        return tenantIdClaimValue.substring(prefix.length);
+    }
+    return undefined;
+};
+
+/**
+ * Evaluates if tenant id url param value is included in custom claim, or not.
+ * @param tenantIdFromCustomClaim Possible tenant id values from custom claim
+ * @param prefix The optional prefix for tenantIdClaimValue
+ * @param tenantIdFromPath The tenant id url parameter to test
+ * @returns true access granted, false denied
+ */
+function grantAccessForCustomClaim(
+    tenantIdFromCustomClaim: any,
+    prefix: string | undefined,
+    tenantIdFromPath: string,
+): string | undefined {
+    let tenantIdFromCustomClaimAsArray: (string | undefined)[] = [];
+    if (tenantIdFromCustomClaim && Array.isArray(tenantIdFromCustomClaim)) {
+        tenantIdFromCustomClaimAsArray = tenantIdFromCustomClaim
+            .map((tenantIdClaimValue: string) => getTenantIdFromCustomClaimValue(tenantIdClaimValue, prefix))
+            .filter((tenantIdCandidate: any) => tenantIdCandidate !== undefined);
+    }
+
+    if (typeof tenantIdFromCustomClaim === 'string') {
+        tenantIdFromCustomClaimAsArray = [tenantIdFromCustomClaim];
+    }
+
+    // Multiple possible tenant id values in custom claim is only supported, if a tenantId from url path is available
+    if (tenantIdFromCustomClaimAsArray.length > 1 && tenantIdFromPath !== undefined) {
+        if (tenantIdRegex.test(tenantIdFromPath) && tenantIdFromCustomClaimAsArray.includes(tenantIdFromPath)) {
+            return tenantIdFromPath;
+        }
+    }
+
+    if (tenantIdFromCustomClaimAsArray.length === 1) {
+        const tenantIdCandidate: string = tenantIdFromCustomClaimAsArray[0]!;
+        if (
+            tenantIdRegex.test(tenantIdCandidate) &&
+            (tenantIdFromPath === undefined || tenantIdFromPath === tenantIdCandidate)
+        ) {
+            return tenantIdCandidate;
+        }
+    }
+
+    return undefined;
+}
+
+/**
+ * Evaluates if tenant id url param value matches with aud claim value, or not.
+ * @param tenantIdFromAudClaim Possible tenant id value from aud claim
+ * @param tenantId The tenant id url parameter to test
+ * @returns true access granted, false denied
+ */
+function grantAccessForAudClaim(tenantIdFromAudClaim: any | undefined, tenantIdFromPath: string): string | undefined {
+    if (
+        tenantIdRegex.test(tenantIdFromAudClaim) &&
+        (tenantIdFromPath === undefined || tenantIdFromPath === tenantIdFromAudClaim)
+    ) {
+        return tenantIdFromAudClaim;
+    }
+    return undefined;
+}
+
+/**
  * Sets the value of `res.locals.tenantId`
  * tenantId is used to identify tenants in a multi-tenant setup
  */
@@ -56,8 +142,25 @@ export const setTenantIdMiddleware: (
     fhirConfig: FhirConfig,
 ) => (req: express.Request, res: express.Response, next: express.NextFunction) => void = (fhirConfig: FhirConfig) => {
     return RouteHelper.wrapAsync(async (req: express.Request, res: express.Response, next: express.NextFunction) => {
-        // Find tenantId from custom claim and aud claim
+        if (req.params.tenantIdFromPath) {
+            // The default tenant is always allowed to be accessed
+            // It shall contain resources, which are shared by multiple tenants, e.g. CodingSystems, Questionnaires etc.
+
+            // Also check for an "all tenants" scope, this is relevant for machine to machine access tokens issued via client credential flow (Oauthv2)
+            if (
+                req.params.tenantIdFromPath === 'DEFAULT' ||
+                grantAccessForAllTenants(res.locals.userIdentity, fhirConfig)
+            ) {
+                res.locals.tenantId = req.params.tenantIdFromPath;
+                next();
+                return;
+            }
+        }
+
+        // Find tenantId from custom claim
         const tenantIdFromCustomClaim = get(res.locals.userIdentity, fhirConfig.multiTenancyConfig?.tenantIdClaimPath!);
+
+        // Find tenantId from aud claim
         const tenantIdFromAudClaim = getTenantIdFromAudClaim(res.locals.userIdentity.aud, fhirConfig.server.url);
 
         // TenantId should exist in at least one claim, if exist in both claims, they should be equal
@@ -67,12 +170,15 @@ export const setTenantIdMiddleware: (
         ) {
             throw new UnauthorizedError('Unauthorized');
         }
-        const tenantId = tenantIdFromCustomClaim || tenantIdFromAudClaim;
+        // Check whether to grant access based on given custom claim or aud claim values
+        const tenantId =
+            grantAccessForCustomClaim(
+                tenantIdFromCustomClaim,
+                fhirConfig.multiTenancyConfig?.tenantIdClaimValuePrefix,
+                req.params.tenantIdFromPath,
+            ) || grantAccessForAudClaim(tenantIdFromAudClaim, req.params.tenantIdFromPath);
 
-        if (
-            !tenantIdRegex.test(tenantId) ||
-            (req.params.tenantIdFromPath !== undefined && req.params.tenantIdFromPath !== tenantId)
-        ) {
+        if (!tenantId) {
             throw new UnauthorizedError('Unauthorized');
         }
         res.locals.tenantId = tenantId;


### PR DESCRIPTION
Issue #, if available:
none
Description of changes:
Added HAPI Server like DEFAULT tenant support, 
Added grant access on all tenants by specific scope (required for machine 2 machine auth flow use cases)
If enabled, ensure the correct urls including their tenant ids in transaction and search set bundle responses.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.