### PR TITLE
fix: change content-type to accept header

### DIFF
--- a/src/app.test.ts
+++ b/src/app.test.ts
@@ -29,7 +29,7 @@ describe('generateServerlessRouter', () => {
         app.post('/test', async (req: express.Request, res: express.Response) => {
             res.send({ data: 'test' });
         });
-        const res = await requestWithSupertest.post('/test', {}).set('Content-Type', 'application/json');
+        const res = await requestWithSupertest.post('/test', {}).set('Accept', 'application/json');
         expect(res.headers['content-type']).toEqual('application/json; charset=utf-8');
     });
 });

--- a/src/router/middlewares/setContentType.test.ts
+++ b/src/router/middlewares/setContentType.test.ts
@@ -33,7 +33,7 @@ describe('setContentTypeMiddleware', () => {
         const nextMock = jest.fn();
         const req = {
             headers: {
-                'content-type': 'application/json',
+                accept: 'application/json',
             },
         } as unknown as express.Request;
         const contentType = jest.fn();

--- a/src/router/middlewares/setContentType.test.ts
+++ b/src/router/middlewares/setContentType.test.ts
@@ -29,7 +29,7 @@ describe('setContentTypeMiddleware', () => {
         expect(contentType).toHaveBeenCalledWith('application/fhir+json');
     });
 
-    test('request should return application/json if user sent application/json', async () => {
+    test('request should return application/json if user request application/json in accept header', async () => {
         const nextMock = jest.fn();
         const req = {
             headers: {

--- a/src/router/middlewares/setContentType.ts
+++ b/src/router/middlewares/setContentType.ts
@@ -12,9 +12,7 @@ import express from 'express';
  */
 export const setContentTypeMiddleware = (req: express.Request, res: express.Response, next: express.NextFunction) => {
     try {
-        res.contentType(
-            req.headers['content-type'] === 'application/json' ? 'application/json' : 'application/fhir+json',
-        );
+        res.contentType(req.headers.accept === 'application/json' ? 'application/json' : 'application/fhir+json');
         next();
     } catch (e) {
         next(e);


### PR DESCRIPTION
Issue #167 

Description of changes:

Update `setContentTypeMiddleware` in order to user the **Accept** header.

The "Accept" header field can be used by user agents to specify response media types that are acceptable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.