### PR TITLE
fix: Throw error if url and POSTed resourceType do not match

### DIFF
--- a/src/router/bundle/bundleHandler.test.ts
+++ b/src/router/bundle/bundleHandler.test.ts
@@ -474,7 +474,7 @@ describe('ERROR Cases: Validation of Bundle request', () => {
                 dummyRequestContext,
                 dummyServerUrl,
             ),
-        ).rejects.toThrowError(new InvalidResourceError("resource should have required property 'resourceType'"));
+        ).rejects.toThrowError(new InvalidResourceError("not a valid 'Bundle'"));
     });
 
     test('Bundle request has unsupported operation: SEARCH', async () => {

--- a/src/router/bundle/bundleHandler.ts
+++ b/src/router/bundle/bundleHandler.ts
@@ -164,7 +164,7 @@ export default class BundleHandler implements BundleHandlerInterface {
         serverUrl: string,
         tenantId?: string,
     ) {
-        await validateResource(this.validators, bundleRequestJson, { tenantId });
+        await validateResource(this.validators, 'Bundle', bundleRequestJson, { tenantId });
 
         let requests: BatchReadWriteRequest[];
         try {

--- a/src/router/handlers/resourceHandler.ts
+++ b/src/router/handlers/resourceHandler.ts
@@ -45,14 +45,14 @@ export default class ResourceHandler implements CrudHandlerInterface {
     }
 
     async create(resourceType: string, resource: any, tenantId?: string) {
-        await validateResource(this.validators, resource, { tenantId, typeOperation: 'create' });
+        await validateResource(this.validators, resourceType, resource, { tenantId, typeOperation: 'create' });
 
         const createResponse = await this.dataService.createResource({ resourceType, resource, tenantId });
         return createResponse.resource;
     }
 
     async update(resourceType: string, id: string, resource: any, tenantId?: string) {
-        await validateResource(this.validators, resource, { tenantId, typeOperation: 'update' });
+        await validateResource(this.validators, resourceType, resource, { tenantId, typeOperation: 'update' });
 
         const updateResponse = await this.dataService.updateResource({ resourceType, id, resource, tenantId });
         return updateResponse.resource;

--- a/src/router/validation/validationUtilities.test.ts
+++ b/src/router/validation/validationUtilities.test.ts
@@ -28,19 +28,30 @@ describe('validateResource', () => {
             throw new InvalidResourceError('Failed validation from validator B');
         },
     };
+    const fakeResourceType = 'Patient';
+    const fakeResource = { resourceType: fakeResourceType };
+    test('non-matching resourceType', async () => {
+        await expect(
+            validateResource([mockedSuccessValidator, mockedSuccessValidator], 'Fake', fakeResource),
+        ).rejects.toThrowError(new InvalidResourceError("not a valid 'Fake'"));
+    });
     test('All validators passes', async () => {
-        await expect(validateResource([mockedSuccessValidator, mockedSuccessValidator], {})).resolves.toEqual(
-            undefined,
-        );
+        await expect(
+            validateResource([mockedSuccessValidator, mockedSuccessValidator], fakeResourceType, fakeResource),
+        ).resolves.toEqual(undefined);
     });
     test('One validator fails', async () => {
-        await expect(validateResource([mockedSuccessValidator, mockedFailedValidatorB], {})).rejects.toThrowError(
-            new InvalidResourceError('Failed validation from validator B'),
-        );
+        await expect(
+            validateResource([mockedSuccessValidator, mockedFailedValidatorB], fakeResourceType, fakeResource),
+        ).rejects.toThrowError(new InvalidResourceError('Failed validation from validator B'));
     });
     test('Validator fails in order', async () => {
         await expect(
-            validateResource([mockedSuccessValidator, mockedFailedValidatorA, mockedFailedValidatorB], {}),
+            validateResource(
+                [mockedSuccessValidator, mockedFailedValidatorA, mockedFailedValidatorB],
+                fakeResourceType,
+                fakeResource,
+            ),
         ).rejects.toThrowError(new InvalidResourceError('Failed validation from validator A'));
     });
 });

--- a/src/router/validation/validationUtilities.ts
+++ b/src/router/validation/validationUtilities.ts
@@ -3,13 +3,17 @@
  *  SPDX-License-Identifier: Apache-2.0
  */
 
-import { TypeOperation, Validator } from 'fhir-works-on-aws-interface';
+import { InvalidResourceError, TypeOperation, Validator } from 'fhir-works-on-aws-interface';
 
 export async function validateResource(
     validators: Validator[],
+    resourceType: string,
     resource: any,
     params: { tenantId?: string; typeOperation?: TypeOperation } = {},
 ): Promise<void> {
+    if (resourceType !== resource.resourceType){
+        throw new InvalidResourceError(`not a valid '${resourceType}'`);
+    }
     for (let i = 0; i < validators.length; i += 1) {
         // eslint-disable-next-line no-await-in-loop
         await validators[i].validate(resource, params);

--- a/src/router/validation/validationUtilities.ts
+++ b/src/router/validation/validationUtilities.ts
@@ -11,7 +11,7 @@ export async function validateResource(
     resource: any,
     params: { tenantId?: string; typeOperation?: TypeOperation } = {},
 ): Promise<void> {
-    if (resourceType !== resource.resourceType){
+    if (resourceType !== resource.resourceType) {
         throw new InvalidResourceError(`not a valid '${resourceType}'`);
     }
     for (let i = 0; i < validators.length; i += 1) {


### PR DESCRIPTION
Issue #, if available: https://github.com/awslabs/fhir-works-on-aws-deployment/issues/682

Description of changes: validating that url resourceType and resource's resourceType is the same

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.