### PR TITLE
adding prefix url to server

### DIFF
--- a/src/app.test.ts
+++ b/src/app.test.ts
@@ -33,3 +33,29 @@ describe('generateServerlessRouter', () => {
         expect(res.headers['content-type']).toEqual('application/json; charset=utf-8');
     });
 });
+
+describe('generateServerlessRouter with prefix url', () => {
+    const fhirConfig = r4FhirConfigNoGeneric();
+    fhirConfig.server.prefix = 'server';
+    fhirConfig.profile.genericResource!.typeSearch = {
+        async getCapabilities() {
+            return {};
+        },
+        typeSearch(request) {
+            throw new Error('Method not implemented.');
+        },
+        globalSearch(request) {
+            throw new Error('Method not implemented.');
+        },
+        validateSubscriptionSearchCriteria(searchCriteria) {
+            throw new Error('Method not implemented.');
+        },
+    };
+    const app = generateServerlessRouter(fhirConfig, ['Patient']);
+    const requestWithSupertest = request(app);
+
+    test('Get metadata request with baseUrl should return status 200', async () => {
+        const res = await requestWithSupertest.get('/server/metadata');
+        expect(res.status).toEqual(200);
+    });
+});

--- a/src/app.ts
+++ b/src/app.ts
@@ -216,10 +216,11 @@ export function generateServerlessRouter(
     mainRouter.use(httpErrorHandler);
     mainRouter.use(unknownErrorHandler);
 
+    const baseUrl = fhirConfig.server.prefix ? `/${fhirConfig.server.prefix}` : '';
     if (fhirConfig.multiTenancyConfig?.enableMultiTenancy && fhirConfig.multiTenancyConfig?.useTenantSpecificUrl) {
-        app.use('/tenant/:tenantIdFromPath([a-zA-Z0-9\\-_]{1,64})', mainRouter);
+        app.use(`${baseUrl}/tenant/:tenantIdFromPath([a-zA-Z0-9\\-_]{1,64})`, mainRouter);
     } else {
-        app.use('/', mainRouter);
+        app.use(`${baseUrl}/`, mainRouter);
     }
 
     return app;


### PR DESCRIPTION
In order to deploy two or more server with different configuration on the same api gateway, the **prefix** params is added.  
If you like this feature, i can create a pull request on the interface repository. 



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.