### PR TITLE
chore: update json5 version

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,8 @@
   "resolutions": {
     "path-parse": "^1.0.7",
     "set-value": "^4.0.1",
-    "qs": "6.10.3"
+    "qs": "6.10.3",
+    "json5": "2.2.3"
   },
   "jest": {
     "moduleFileExtensions": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -3968,19 +3968,10 @@ json-stringify-safe@^5.0.1:
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
   integrity sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=
 
-json5@2.x, json5@^2.1.2:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.0.tgz#2dfefe720c6ba525d9ebd909950f0515316c89a3"
-  integrity sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==
-  dependencies:
-    minimist "^1.2.5"
-
-json5@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/json5/-/json5-1.0.1.tgz#779fb0018604fa854eacbf6252180d83543e3dbe"
-  integrity sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==
-  dependencies:
-    minimist "^1.2.0"
+json5@2.2.3, json5@2.x, json5@^1.0.1, json5@^2.1.2:
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.3.tgz#78cd6f1a19bdc12b73db5ad0c61efd66c1e29283"
+  integrity sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==
 
 jsonparse@^1.2.0:
   version "1.3.1"


### PR DESCRIPTION
Issue #, if available:
Update JSON5 package version

Description of changes:
There were upstream dependencies that depended on vulnerable version of JSON5, which is why we're choosing to update its version in resolutions.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.