### PR TITLE
Revert "deprecate package"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 # fhir-works-on-aws-routing
-# This GitHub repository has been migrated. You can now find FHIR Works on AWS at https://github.com/aws-solutions/fhir-works-on-aws.
 
 ## Purpose
 


### PR DESCRIPTION
Reverts awslabs/fhir-works-on-aws-routing#198